### PR TITLE
Feature/create block fees submodule

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -315,7 +315,7 @@ pub const MAX_BLOCK_WEIGHT: usize = 40_000;
 pub const MAINNET_FIRST_HARD_FORK: u64 = 1300000;
 
 /// Floonet first hard fork height
-pub const FLOONET_FIRST_HARD_FORK: u64 = 5800;
+pub const FLOONET_FIRST_HARD_FORK: u64 = 25800;
 
 /// AutomatedTesting and UserTesting first hard fork height.
 pub const TESTING_FIRST_HARD_FORK: u64 = 6;

--- a/core/src/core.rs
+++ b/core/src/core.rs
@@ -15,6 +15,7 @@
 //! Core types
 
 pub mod block;
+pub mod block_fees;
 pub mod block_sums;
 pub mod committed;
 pub mod compact_block;

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -170,7 +170,6 @@ impl Writeable for HeaderEntry {
 	}
 }
 
-
 impl Hashed for HeaderEntry {
 	/// The hash of the underlying block.
 	fn hash(&self) -> Hash {
@@ -853,10 +852,7 @@ impl Block {
 	/// Validates all the elements in a block that can be checked without
 	/// additional data. Includes commitment sums and kernels, Merkle
 	/// trees, reward, etc.
-	pub fn validate(
-		&self,
-		prev_kernel_offset: &BlindingFactor,
-	) -> Result<Commitment, Error> {
+	pub fn validate(&self, prev_kernel_offset: &BlindingFactor) -> Result<Commitment, Error> {
 		self.body.validate(Weighting::AsBlock)?;
 
 		self.verify_kernel_lock_heights()?;

--- a/core/src/core/block_fees.rs
+++ b/core/src/core/block_fees.rs
@@ -1,0 +1,38 @@
+// Copyright 2018 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::keychain::Identifier;
+use crate::libtx::secp_ser;
+use serde::{Deserialize, Serialize};
+
+/// Fees in block to use for coinbase amount calculation
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct BlockFees {
+	/// fees
+	#[serde(with = "secp_ser::string_or_u64")]
+	pub fees: u64,
+	/// height
+	#[serde(with = "secp_ser::string_or_u64")]
+	pub height: u64,
+	/// key id
+	pub key_id: Option<Identifier>,
+}
+
+/// Implementing the key id
+impl BlockFees {
+	/// return key id
+	pub fn key_id(&self) -> Option<Identifier> {
+		self.key_id.clone()
+	}
+}

--- a/core/src/core/foundation.rs
+++ b/core/src/core/foundation.rs
@@ -102,6 +102,6 @@ pub fn load_foundation_output(height: u64) -> CbData {
 	file.seek(SeekFrom::Start(offset)).unwrap();
 	file.read_exact(&mut buffer).unwrap();
 	let buffer_str = String::from_utf8(buffer).unwrap();
-	
+
 	serde_json::from_str(&buffer_str).unwrap()
 }

--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -17,9 +17,7 @@
 //! Primary hash function used in the protocol
 //!
 
-use crate::ser::{
-	self, AsFixedBytes, Error, ProtocolVersion, Readable, Reader, Writeable, Writer,
-};
+use crate::ser::{self, AsFixedBytes, Error, ProtocolVersion, Readable, Reader, Writeable, Writer};
 use blake2::blake2b::Blake2b;
 use byteorder::{BigEndian, ByteOrder};
 use std::cmp::min;
@@ -64,9 +62,7 @@ impl fmt::Display for Hash {
 	}
 }
 
-
 impl Hash {
-
 	/// A hash is 32 bytes.
 	pub const LEN: usize = 32;
 

--- a/servers/src/foundation.rs
+++ b/servers/src/foundation.rs
@@ -1,6 +1,8 @@
 use crate::core::consensus;
 use crate::mining::mine_block::create_foundation as c_foundation;
-use crate::mining::mine_block::{BlockFees, CbData};
+use crate::mining::mine_block::CbData;
+
+use crate::core::core::block_fees::BlockFees;
 
 /// Call the wallet API to create a given number of foundations coinbases (output/kernel)
 pub fn create_foundation(

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -33,33 +33,14 @@ pub use crate::core::core::foundation::CbData;
 use crate::core::core::hash::{Hash, Hashed};
 use crate::core::core::{Output, TxKernel};
 use crate::core::global::{get_emitted_policy, get_policies};
-use crate::core::libtx::secp_ser;
 use crate::core::libtx::ProofBuilder;
 use crate::core::pow::randomx::rx_current_seed_height;
 use crate::core::pow::PoWType;
 use crate::core::{consensus, core, global};
 use crate::keychain::{ExtKeychain, Identifier, Keychain};
 use crate::pool;
-/// Fees in block to use for coinbase amount calculation
-/// (Duplicated from Epic wallet project)
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockFees {
-	/// fees
-	#[serde(with = "secp_ser::string_or_u64")]
-	pub fees: u64,
-	/// height
-	#[serde(with = "secp_ser::string_or_u64")]
-	pub height: u64,
-	/// key id
-	pub key_id: Option<Identifier>,
-}
 
-impl BlockFees {
-	/// return key id
-	pub fn key_id(&self) -> Option<Identifier> {
-		self.key_id.clone()
-	}
-}
+use crate::core::core::block_fees::BlockFees;
 
 /// Response to build a coinbase output.
 /*#[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
This MR creates a separate submodule named `block_fees`. This submodule contains the definition of the `BlockFees` struct. This was redefined here, copied from the `epic-wallet` project. Since it is also used by `epic-wallet-address`, then I think it will be useful to share this struct between all projects. 

The `epic-wallet-address` had an old copy of this code, so one can't use the wallet713 while mining due to wrong serialization and deserialization.

I'll perform the same update on the other projects, they will reuse this submodule defined in this MR.