### PR TITLE
Draft: Doubling the value of the MAINNET_FIRST_HARD_FORK constant

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -311,8 +311,10 @@ pub const BLOCK_KERNEL_WEIGHT: usize = 3;
 ///
 pub const MAX_BLOCK_WEIGHT: usize = 40_000;
 
-/// Mainnet first hard fork height, set to happen around 2020-04-29
-pub const MAINNET_FIRST_HARD_FORK: u64 = 1300000;
+/// Mainnet first hard fork height
+/// Doubled from the previous hard coded value 1300000
+/// We might need to change this later for final release
+pub const MAINNET_FIRST_HARD_FORK: u64 = 2600000;
 
 /// Floonet first hard fork height
 pub const FLOONET_FIRST_HARD_FORK: u64 = 25800;


### PR DESCRIPTION
The MainNet has more than `1300000` blocks now. So this initial value for the MAINNET_FIRST_HARD_FORK is outdated. I'm doubling it for now and finish the PR after confirming the best value.