### PR TITLE
Feat/get blocks

### DIFF
--- a/api/src/foreign.rs
+++ b/api/src/foreign.rs
@@ -14,6 +14,7 @@
 
 //! Foreign API External Definition
 
+use epic_core::core::TxKernel;
 use crate::chain::{Chain, SyncState};
 use crate::core::core::hash::Hash;
 use crate::core::core::transaction::Transaction;
@@ -181,6 +182,20 @@ impl Foreign {
 			chain: self.chain.clone(),
 		};
 		kernel_handler.get_kernel_v2(excess, min_height, max_height)
+	}
+
+	pub fn get_last_n_kernels(
+		&self,
+		distance: u64,
+	) -> Result<Vec<TxKernel>, Error>{
+		let kernel_handler = KernelHandler {
+			chain: self.chain.clone()
+		};
+		let kernels = kernel_handler.get_last_n_kernels(distance);
+		match kernels {
+			Ok(k) => Ok(k),
+			Err(k) => Err(k)
+		}
 	}
 
 	/// Retrieves details about specifics outputs. Supports retrieval of multiple outputs in a single request.

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -14,6 +14,7 @@
 
 //! JSON-RPC Stub generation for the Foreign API
 
+use epic_core::core::TxKernel;
 use crate::core::core::hash::Hash;
 use crate::core::core::transaction::Transaction;
 use crate::foreign::Foreign;
@@ -375,6 +376,44 @@ pub trait ForeignRpc: Sync + Send {
 		min_height: Option<u64>,
 		max_height: Option<u64>,
 	) -> Result<LocatedTxKernel, ErrorKind>;
+
+	/*
+	# Json rpc example
+
+	```
+	# epic_api::doctest_helper_json_rpc_foreign_assert_response!(
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"method": "get_last_n_kernels",
+		"params": [1],
+		"id": 1
+	}
+	# "#
+	# ,
+	# r#"
+	{
+		"id": 1,
+		"jsonrpc": "2.0",
+		"result": {
+			"Ok": [
+			{
+				"excess": "08fa0cecd81956afb1b45cb749ff04291c9d8b711c780921995d81f5710f663ccd",
+				"excess_sig": "db717651f56341bdfcfe90427f5aa2c7dae81a46090301194259f9bbc2f98c9c5154a65a9c6ce9c0d9851383a4f0fe63d42b2ca93247322f4830788c947168b1",
+				"features": "Coinbase"
+			}
+			]
+		}
+	}
+	# "#
+	# );
+	```
+	*/
+
+	fn get_last_n_kernels(
+		&self,
+		distance: u64,
+	) -> Result<Vec<TxKernel>, ErrorKind>;
 
 	/**
 	Networked version of [Foreign::get_outputs](struct.Node.html#method.get_outputs).
@@ -826,6 +865,16 @@ impl ForeignRpc for Foreign {
 		return Err(ErrorKind::Argument(
 			"Start_height or end_height is not valid".to_string(),
 		));
+	}
+
+	fn get_last_n_kernels(
+		&self,
+		distance: u64,
+	) -> Result<Vec<TxKernel>, ErrorKind>{
+		match Foreign::get_last_n_kernels(self, distance) {
+			Ok(k) => Ok(k),
+			Err(k) => Err(ErrorKind::Argument("Could not get kernels".to_string()))
+		}
 	}
 
 	fn get_version(&self) -> Result<Version, ErrorKind> {

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -785,7 +785,9 @@ impl ForeignRpc for Foreign {
 		commit: Option<String>,
 	) -> Result<Vec<BlockPrintable>, ErrorKind> {
 		if Some(start_height) > Some(end_height) {
-			return Err(ErrorKind::Argument("Start_height must be lower or equal than end_height".to_string()))
+			return Err(ErrorKind::Argument(
+				"Start_height must be lower or equal than end_height".to_string(),
+			));
 		}
 		let mut parsed_hash: Option<Hash> = None;
 		if let Some(hash) = hash {
@@ -797,13 +799,16 @@ impl ForeignRpc for Foreign {
 			if let Some(end_height) = end_height {
 				let mut blocks: Vec<BlockPrintable> = vec![];
 				for height in start_height..=end_height {
-					let block = Foreign::get_block(self, Some(height), parsed_hash, commit.clone()).map_err(|e| e.kind().clone())?;
+					let block = Foreign::get_block(self, Some(height), parsed_hash, commit.clone())
+						.map_err(|e| e.kind().clone())?;
 					blocks.push(block);
 				}
 				return Ok(blocks);
 			}
-		}	
-		return Err(ErrorKind::Argument("Start_height or end_height is not valid".to_string()));	
+		}
+		return Err(ErrorKind::Argument(
+			"Start_height or end_height is not valid".to_string(),
+		));
 	}
 
 	fn get_version(&self) -> Result<Version, ErrorKind> {

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -800,8 +800,11 @@ impl ForeignRpc for Foreign {
 				let mut blocks: Vec<BlockPrintable> = vec![];
 				for height in start_height..=end_height {
 					let block = Foreign::get_block(self, Some(height), parsed_hash, commit.clone())
-						.map_err(|e| e.kind().clone())?;
-					blocks.push(block);
+						.map_err(|e| e.kind().clone());
+					match block {
+						Ok(b) => blocks.push(b),
+						Err(_) => (),
+					}
 				}
 				return Ok(blocks);
 			}

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -243,6 +243,20 @@ pub trait ForeignRpc: Sync + Send {
 		commit: Option<String>,
 	) -> Result<BlockPrintable, ErrorKind>;
 
+	/*
+	# Json rpc example
+
+	```
+	# epic_api::doctest_helper_json_rpc_foreign_assert_response!(
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"method": "get_blocks",
+		"params": [1, 3, null, null],
+		"id": 1
+	}
+	*/
+
 	fn get_blocks(
 		&self,
 		start_height: Option<u64>,

--- a/api/src/handlers/chain_api.rs
+++ b/api/src/handlers/chain_api.rs
@@ -21,6 +21,7 @@ use crate::types::*;
 use crate::util;
 use crate::util::secp::pedersen::Commitment;
 use crate::web::*;
+use epic_core::core::TxKernel;
 use failure::ResultExt;
 use hyper::{Body, Request, StatusCode};
 use std::sync::Weak;
@@ -464,6 +465,20 @@ impl KernelHandler {
 				mmr_index,
 			});
 		kernel.ok_or_else(|| ErrorKind::NotFound.into())
+	}
+
+	pub fn get_last_n_kernels(
+		&self,
+		distance: u64,
+	) -> Result<Vec<TxKernel>, Error> {
+		let chain = w(&self.chain)?;
+		let kernels = chain.get_last_n_kernel(distance);
+		let mut tx_kernels: Vec<TxKernel> = Vec::new();
+		for k in &kernels {
+			let tx_kernel = k.1.clone();
+			tx_kernels.push(tx_kernel);
+		};
+		return Ok(tx_kernels);
 	}
 }
 


### PR DESCRIPTION
New method to get the n last kernels and get a set of blocks from the blockchain. Useful for counting the total transactions.

get_last_n_kernels() returns the n kernels starting from the ones on the current chain height. The have the kenel's excess, signature, fee and type of kernel (coinbase or plain).

get_blocks() is similar to the get_block() method. However, instead of returning a single block result, it returns a list of blocks in a specified range. In case the range include pruned blocks, they will not be in the response set.