### PR TITLE
feat: Added feedback if foundations are broken

### DIFF
--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -255,6 +255,7 @@ pub fn use_alternative_path(path_str: String) -> String {
 			check_path.display(),
 			p.display()
 		);
+		println!("The file `{}` was not found! Will try to use the alternative file `{}`!", check_path.display(), p.display());
 		p.to_str().expect("Failed to get the executable's directory and no path to the foundation.json was provided!").to_owned()
 	} else {
 		path_str
@@ -607,8 +608,13 @@ impl Version {
 	}
 }
 
+/// Get the sha256 of file
 pub fn get_file_sha256(path: &str) -> String {
-	let mut file = File::open(path).expect(
+	let file_open = File::open(path);
+	if file_open.is_err() {
+		println!("\nCouldn't open the foundation file!\nCheck if the file \"{}\" was not changed!",path);
+	};
+	let mut file = file_open.expect(
 		format!(
 			"Error trying to read the foundation.json. Couldn't find/open the file {}!",
 			path

--- a/servers/src/epic/server.rs
+++ b/servers/src/epic/server.rs
@@ -116,6 +116,7 @@ impl Server {
 		if hash.as_str() != hash_to_compare {
 			error!("Invalid {} file!\nThe sha256 of this file should be: {} - {}\nCheck if the file was not changed!", global::get_foundation_path().unwrap(), hash_to_compare, hash.as_str());
 			error!("Closing the application!");
+			println!("\nInvalid foundation file!\nCheck if the file \"{}\" was not changed!",global::get_foundation_path().unwrap());
 			std::process::exit(1);
 		}
 		let mining_config = config.stratum_mining_config.clone();


### PR DESCRIPTION
We can have up to two foundations files, the one from epic-server.toml and the default one inside the `/epic/debian/` folder. We can have two types of problems:

Error1 - The file path is wrong or the file does not exist in the folder;
Error2 - The file exists but is not correct (corrupted, has been changed, is a foundation not valid for this version).

With this we can have 6 possible scenarios:

1 - Both foundations are correct;
The system will run without printing anything.

2 - toml-foundation is right and default-foundation is wrong;
The system will run without printing anything. Regardless if the problem in the default-foundation is Error1 or Error2.

3 - toml-foundation has Error1 and default-foundation is right;

The system will show the following message:
```
The file `/home/ba/Desktop/Foundation/foundation-v4.json` was not found! Will try to use the alternative file `/home/ba/epic/debian/foundation_floonet.json`!
```
And it **will start normally**.

4 - toml-foundation has Error2 and default-foundation is right OR Both foundations have Error2 OR toml-foundation has Error2 and default-foundation has Error1;

The system will show the following message:
```

Invalid foundation file!
Check if the file "/home/ba/Desktop/Foundation/foundation-v3.json" was not changed!
```
And it **won't start**.

5 - Both foundations have Error1;
The system will show the following message:

```
The file `/home/ba/Desktop/Foundation/foundation-v4.json` was not found! Will try to use the alternative file `/home/ba/epic/debian/foundation_floonet.json`!

Couldn't open the foundation file!
Check if the file "/home/ba/epic/debian/foundation_floonet.json" was not changed!
```
And it **won't start**.

6 - toml-foundation with Error1 and default-foundation with Error2;
The system will show the following message:

```
The file `/home/ba/Desktop/Foundation/foundation-v4.json` was not found! Will try to use the alternative file `/home/ba/Desktop/EpicV3/epic/debian/foundation_floonet.json`!

Invalid foundation file!
Check if the file "/home/ba/epic/debian/foundation_floonet.json" was not changed!
```
And it **won't start**.

Note: All paths are for example only.