### PR TITLE
Fix cucumber tests

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -107,7 +107,11 @@ pub const MAINNET_FOUNDATION_HEIGHT: u64 = DAY_HEIGHT;
 
 /// Set the height (and its multiples) where the foundation coinbase will be added to the block.
 /// Used in automated tests.
-pub const AUTOMATEDTEST_FOUNDATION_HEIGHT: u64 = DAY_HEIGHT;
+pub const AUTOMATEDTEST_FOUNDATION_HEIGHT: u64 = 5;
+
+/// Set the height (and its multiples) where the foundation coinbase will be added to the block.
+/// Used in Usernet.
+pub const USERNET_FOUNDATION_HEIGHT: u64 = DAY_HEIGHT;
 
 /// Set the height (and its multiples) where the foundation coinbase will be added to the block.
 /// Used in the Floonet.
@@ -118,7 +122,7 @@ pub fn foundation_height() -> u64 {
 	let param_ref = global::CHAIN_TYPE.read();
 	match *param_ref {
 		global::ChainTypes::AutomatedTesting => AUTOMATEDTEST_FOUNDATION_HEIGHT,
-		global::ChainTypes::UserTesting => AUTOMATEDTEST_FOUNDATION_HEIGHT,
+		global::ChainTypes::UserTesting => USERNET_FOUNDATION_HEIGHT,
 		global::ChainTypes::Floonet => FLOONET_FOUNDATION_HEIGHT,
 		_ => MAINNET_FOUNDATION_HEIGHT,
 	}

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -1,6 +1,6 @@
 // Copyright 2018 The Grin Developers
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
+// Licensed under the &Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -245,6 +245,10 @@ pub fn use_alternative_path(path_str: String) -> String {
 	let mut p = env::current_exe().expect(
 		"Failed to get the executable's directory and no path to the foundation.json was provided!",
 	);
+	//if we run the "cargo test --release" the p contains "cucumber_..." in last folder
+	if p.file_stem().unwrap().to_str().unwrap().contains(&"cucumber") {
+		return path_str;
+	}
 	//removing the file from the path and going back 2 directories
 	for _ in 0..3 {
 		p.pop();

--- a/features/mine_chain.feature
+++ b/features/mine_chain.feature
@@ -464,3 +464,16 @@ Scenario: refuse invalid progpow pow
   Then I refuse a block with <progpow> invalid
   Then clean tmp chain dir
   Then clean output dir
+
+
+Scenario: refuse invalid cuckatoo pow
+  Given I have the policy <0> with <cuckaroo> equals <0>
+  And I have the policy <0> with <randomx> equals <0>
+  And I have the policy <0> with <cuckatoo> equals <100>
+  And I setup all the policies
+  Given I have a <testing> chain
+  And I define my output dir as <.epic10>
+  And I setup a chain
+  Then I refuse a block with <cuckoo> invalid
+  Then clean tmp chain dir
+  Then clean output dir

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -751,7 +751,6 @@ mod mine_chain {
 				let chain = world.chain.as_ref().unwrap();
 				let kc_foundation = world.keychain_foundation.as_ref().unwrap();
 				let kc = world.keychain.as_ref().unwrap();
-
 				let prev = chain.head_header().unwrap();
 				let height = prev.height + 1;
 				let diff = height;
@@ -1849,7 +1848,7 @@ mod mine_chain {
 
 // Declares a before handler function named `a_before_fn`
 before!(a_before_fn => |_scenario| {
-	println!("Test 1");
+	println!("Testing a_before_fn ----------------------------------\n++++++++++++++++++++++++++++++\n----------------------------------\n----------------------------------\n");
 	global::set_foundation_path("./tests/assets/foundation.json".to_string());
 });
 
@@ -1860,6 +1859,7 @@ after!(an_after_fn => |_scenario| {
 
 // A setup function to be called before everything else
 fn setup() {
+	global::set_foundation_path("./tests/assets/foundation.json".to_string());
 	let policies = [
 		(FType::Cuckaroo, 100),
 		(FType::Cuckatoo, 0),
@@ -1894,10 +1894,9 @@ fn setup() {
 		policies: vec![policies, policies2, policies3],
 		..Default::default()
 	});
-
 	util::init_test_logger();
 }
-
+/// To run cucumber test: cargo test --package epic --test cucumber
 cucumber! {
 	features: "./features", // Path to our feature files
 	world: crate::EdnaWorld, // The world needs to be the same for steps and the main cucumber call


### PR DESCRIPTION
With the recent changes made, some functions were changed causing a lot of bugs in the Cucumber tests, for that we adjusted most of them.

We still have some not-so-needed tests at the moment to adjust. These are:

- mine empty chain
- mine genesis reward chain ("Not Implemented")
- mine cuckatoo genesis reward chain
- output header mappings
- mine randomx genesis reward chain
- mine progpow genesis reward chain