### PR TITLE
Freeze randomx and progpow libraries using tags

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,8 +38,8 @@ zeroize = "1.3.0"
 
 keychain = { package = "epic_keychain", path = "../keychain", version = "3.0.0" }
 util = { package = "epic_util", path = "../util", version = "3.0.0" }
-randomx = { git = "https://github.com/EpicCash/randomx-rust.git", version = "0.1.1" }
-progpow = { git = "https://github.com/EpicCash/progpow-rust.git", version = "0.1.0" }
+randomx = { git = "https://github.com/EpicCash/randomx-rust.git", tag = "v0.1.1" }
+progpow = { git = "https://github.com/EpicCash/progpow-rust.git", tag = "v0.1.0" }
 
 [dev-dependencies]
 serde_json = "1"


### PR DESCRIPTION
# Description

Since now we have the releases for progpow and randomx, we can change the versioning system to use tags.

This will allow us to have a better version control

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Build changes (changes the way the project builds)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested by building the projects using cargo

# Relevant notes

Tags used:
- https://github.com/EpicCash/progpow-rust/releases/tag/v0.1.0
- https://github.com/EpicCash/randomx-rust