### PR TITLE
Remove foundation_floonet.json references

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -56,11 +56,8 @@ fn get_epic_path(chain_type: &global::ChainTypes) -> Result<PathBuf, ConfigError
 	Ok(epic_path)
 }
 
-fn get_foundation_path(chain_type: &global::ChainTypes) -> String {
-	let foundation_name = match *chain_type {
-		global::ChainTypes::Mainnet => "foundation.json",
-		_ => "foundation_floonet.json",
-	};
+fn get_foundation_path(_: &global::ChainTypes) -> String {
+	let foundation_name = "foundation.json";
 
 	if cfg!(windows) {
 		format!(".\\{}", foundation_name).to_owned()

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -234,7 +234,6 @@ pub fn set_foundation_path(path: String) {
 
 ///	Check if the foundation.json exists in the directory appointed by the .toml file, if not,
 /// use the alternative path ../../debian/foundation.json relative to the folder where the executable is in.
-/// If we are running floonet, it will look for the file foundation_floonet.json .
 pub fn use_alternative_path(path_str: String) -> String {
 	let check_path = Path::new(&path_str);
 	if check_path.exists() {
@@ -246,7 +245,12 @@ pub fn use_alternative_path(path_str: String) -> String {
 		"Failed to get the executable's directory and no path to the foundation.json was provided!",
 	);
 	//if we run the "cargo test --release" the p contains "cucumber_..." in last folder
-	if p.file_stem().unwrap().to_str().unwrap().contains(&"cucumber") {
+	if p.file_stem()
+		.unwrap()
+		.to_str()
+		.unwrap()
+		.contains(&"cucumber")
+	{
 		return path_str;
 	}
 	//removing the file from the path and going back 2 directories
@@ -254,10 +258,7 @@ pub fn use_alternative_path(path_str: String) -> String {
 		p.pop();
 	}
 	p.push("debian");
-	let foundation_name = match CHAIN_TYPE.read().clone() {
-		ChainTypes::Mainnet => "foundation.json",
-		_ => "foundation_floonet.json",
-	};
+	let foundation_name = "foundation.json";
 	p.push(foundation_name);
 	if check_path.exists() {
 		warn!(

--- a/debian/epic.postinst
+++ b/debian/epic.postinst
@@ -1,4 +1,3 @@
 #!/bin/sh
 
 chmod ugo+r /usr/share/epic/foundation.json
-chmod ugo+r /usr/share/epic/foundation_floonet.json

--- a/debian/rules
+++ b/debian/rules
@@ -25,7 +25,6 @@ binary binary-arch binary-indep: build/stamp debian/control
 	dh_prep
 	mkdir -p $(ROOTDIR)/usr/share/epic/
 	install -m 666 debian/foundation.json $(ROOTDIR)/usr/share/epic/foundation.json
-	install -m 666 debian/foundation_floonet.json $(ROOTDIR)/usr/share/epic/foundation_floonet.json
 	cargo install --path . --root $(ROOTDIR)/usr/ --locked
 	cargo install --path bugreport --root $(ROOTDIR)/usr/ --locked
 	strip $(ROOTDIR)/usr/bin/epic


### PR DESCRIPTION
# Description

- Remove references to `foundation_floonet.json`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (miscellaneous changes e.g. modifying .gitignore)
- [ ] Build (Affect build components like build tool, ci pipeline, dependencies, project version)
- [ ] Docs (documentation update)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes

- Tested locally on a Linux machine

# Relevant notes

The foundation.json and foundation_flootnet.json were changed to be the same since version 3.3.2.