### PR TITLE
Add 'only_randomx' and 'no_progpow' options to config

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -149,6 +149,24 @@ fn comments() -> HashMap<String, String> {
 	);
 
 	retval.insert(
+		"only_randomx".to_string(),
+		"
+#Whether or not to set PolicyConfig to only use PoWType::RandomX.
+#Required for use of Floonet, has no effect on Mainnet
+"
+		.to_string(),
+	);
+
+	retval.insert(
+		"no_progpow".to_string(),
+		"
+#Whether or not to set PolicyConfig to disable PoWType::ProgPow
+#For use on Floonet or Usernet. Has no effect on Mainnet
+"
+		.to_string(),
+	);
+
+	retval.insert(
 		"[server.dandelion_config]".to_string(),
 		"
 #########################################

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -21,7 +21,6 @@ use rand::prelude::*;
 
 use crate::api;
 use crate::chain;
-use crate::core::core::block::feijoada::PolicyConfig;
 use crate::core::global;
 use crate::core::global::ChainTypes;
 use crate::core::{consensus, core, libtx, pow};
@@ -185,6 +184,14 @@ pub struct ServerConfig {
 	/// if enabled, this will disable logging to stdout
 	pub run_tui: Option<bool>,
 
+	/// Only use PoWType::RandomX in PolicyConfig
+	/// Required for floonet, has no effect on Mainnet
+	pub only_randomx: Option<bool>,
+
+	/// Disable PoWType::ProgPow in PolicyConfig
+	/// For use with Floonet, Usernet. Has no effect on Mainnet
+	pub no_progpow: Option<bool>,
+
 	/// Whether to run the test miner (internal, cuckoo 16)
 	pub run_test_miner: Option<bool>,
 
@@ -234,6 +241,8 @@ impl Default for ServerConfig {
 			skip_sync_wait: Some(false),
 			header_sync_timeout: 10,
 			run_tui: Some(true),
+			only_randomx: Some(false),
+			no_progpow: Some(false),
 			run_test_miner: Some(false),
 			test_miner_wallet_url: None,
 			webhook_config: WebHooksConfig::default(),
@@ -296,7 +305,7 @@ impl Default for StratumServerConfig {
 				progpow_minimum_share_difficulty: consensus::MIN_DIFFICULTY_PROGPOW,
 				enable_stratum_server: Some(true),
 				stratum_server_addr: Some("127.0.0.1:3416".to_string()),
-			}
+			},
 		}
 	}
 }

--- a/src/bin/epic.rs
+++ b/src/bin/epic.rs
@@ -20,7 +20,6 @@ extern crate clap;
 #[macro_use]
 extern crate log;
 use crate::config::config::SERVER_CONFIG_FILE_NAME;
-use crate::core::core::feijoada::PolicyConfig;
 use crate::core::core::foundation;
 use crate::core::{consensus, global};
 use crate::util::init_logger;
@@ -82,17 +81,6 @@ fn real_main() -> i32 {
 		.version(built_info::PKG_VERSION)
 		.get_matches();
 	let node_config;
-
-	// run floonet and usernet with custom PolicyConfig
-	if args.is_present("floonet") || args.is_present("usernet") {
-		if args.is_present("noprogpow") {
-			global::set_policy_config(PolicyConfig::no_progpow());
-		};
-
-		if args.is_present("onlyrandomx") {
-			global::set_policy_config(PolicyConfig::only_randomx());
-		};
-	};
 
 	let chain_type = if args.is_present("floonet") {
 		global::ChainTypes::Floonet


### PR DESCRIPTION
- Removes need to specify these as arguments to server on initialization
- Both config options have no effect on mainnet (added `is_test_network()` boolean fn for checking)
- Above bulletpoint allows these flags to take effect only on `AutomatedTesting`, `UserTesting`, or `Floonet` ChainTypes

Tested and verified functional for cases:

1.) Floonet node where:
- a.) One or both config options are missing from config file
- b.) Both options set to true/false independently

2.) Mainnet node:
- Both options ignored if running server in mainnet mode