### PR TITLE
Don't ban peers that report a higher diff, but can't deliver blocks

### DIFF
--- a/servers/src/epic/sync/header_sync.rs
+++ b/servers/src/epic/sync/header_sync.rs
@@ -148,13 +148,11 @@ impl HeaderSync {
 				if let Some(ref peer) = self.syncing_peer {
 					match self.sync_state.status() {
 						SyncStatus::HeaderSync { .. } | SyncStatus::BodySync { .. } => {
-							// Ban this fraud peer which claims a higher work but can't send us the real headers
+							// Disconnect peer which claims a higher work but can't send us the real headers
 							if now > *stalling_ts + Duration::seconds(120)
 								&& header_head.total_difficulty < peer.info.total_difficulty()
 							{
-								if let Err(e) = self.peers.disconnect_peer(
-									peer.info.addr, /*, ReasonForBan::FraudHeight*/
-								) {
+								if let Err(e) = self.peers.disconnect_peer(peer.info.addr) {
 									error!("failed to disconnect_peer {}: {:?}", peer.info.addr, e);
 								}
 								info!(

--- a/servers/src/epic/sync/header_sync.rs
+++ b/servers/src/epic/sync/header_sync.rs
@@ -152,14 +152,14 @@ impl HeaderSync {
 							if now > *stalling_ts + Duration::seconds(120)
 								&& header_head.total_difficulty < peer.info.total_difficulty()
 							{
-								if let Err(e) = self
-									.peers
-									.ban_peer(peer.info.addr, ReasonForBan::FraudHeight)
-								{
-									error!("failed to ban peer {}: {:?}", peer.info.addr, e);
+								if let Err(e) = self.peers.disconnect_peer(
+									peer.info.addr, /*, ReasonForBan::FraudHeight*/
+								) {
+									error!("failed to disconnect_peer {}: {:?}", peer.info.addr, e);
 								}
 								info!(
-										"sync: ban a fraud peer: {}, claimed height: {}, total difficulty: {}",
+										"sync: disconnect peer, claimed higher work but headers not delivered: {}, \
+										claimed height: {}, total difficulty: {}",
 										peer.info.addr,
 										peer.info.height(),
 										peer.info.total_difficulty(),


### PR DESCRIPTION
Peers were being needlessly banned in cases where we had a disconnection during transport of headers.

This commit simply disconnects from those peers, removing them from our peer list temporarily.  As a result, ban list does not endlessly grow for normal network behavior.