### PR TITLE
Update debian package for 3.4.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+epic (3.4.0) focal; urgency=high
+
+  [ Epic Team ]
+  * Mandatory update for mining policy in upcoming era
+  * Update mining algo policy to 48% ProgPow, 48% Randomx, 4% Cuckatoo for all future eras
+  * New sync_header process for faster initial chain sync
+  * Fixes peer discovery, changes seeding type to List
+  * Update ring dependency to 0.16.x
+
+ -- Epic Team <admin@epic.tech>  Wed, 14 Jun 2023 12:00:00 +0000
+
 epic (3.3.2) bionic; urgency=medium
 
   [ Epic Team ]
@@ -8,6 +19,8 @@ epic (3.3.2) bionic; urgency=medium
   * Add Testnet configuration file
   * Reproducible builds
   * New readme
+
+ -- Epic Team <admin@epic.tech>  Tue, 17 Jan 2023 12:00:00 +0000
 
 epic (3.0.9~alpha-1) UNRELEASED; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -1,12 +1,12 @@
 Source: epic
 Section: utils
 Priority: optional
-Maintainer: Yuri Albuquerque <yurialbuquerque@brickabode.com>
+Maintainer: Epic Team <admin@epic.tech>
 Build-Depends: build-essential, debhelper, cmake, libclang-dev, libncurses5-dev, clang, libncursesw5-dev, cargo, rustc
 Standards-Version: 4.0.0
 Homepage: http://brickabode.com/
 
 Package: epic
 Architecture: amd64
-Depends: libncurses5, libncursesw5, librandomx
+Depends: libncurses5, libncursesw5
 Description: Epic server

--- a/debian/rules
+++ b/debian/rules
@@ -37,4 +37,4 @@ binary binary-arch binary-indep: build/stamp debian/control
 	dh_installdeb
 	dh_gencontrol
 	dh_md5sums
-	dh_builddeb --destdir ./release/epic/
+	dh_builddeb --destdir .


### PR DESCRIPTION
Updates debian package for 3.4.0

- Fixes formatting issues in `debian/changelog`
- Fixes `debian/rules` script, so that resulting package is placed in repository root, rather than `./release/epic` which was not created by default, or by package script.
  - Result was a build error during  when calling `make -f debian/rules binary`. This has been resolved.

- [`015d5da`](https://github.com/EpicCash/epic/pull/94/commits/015d5dab3a3daab69258de8bf4a53a484cc63a80) also updates `debian/control` with new maintainer email address, and removes randomx dependency (no longer required).