### PR TITLE
Resolve most of warnings present when compiling

### DIFF
--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -14,7 +14,6 @@
 
 //! JSON-RPC Stub generation for the Foreign API
 
-use epic_core::core::TxKernel;
 use crate::core::core::hash::Hash;
 use crate::core::core::transaction::Transaction;
 use crate::foreign::Foreign;
@@ -25,6 +24,7 @@ use crate::types::{
 	Version,
 };
 use crate::util;
+use epic_core::core::TxKernel;
 
 /// Public definition used to generate Node jsonrpc api.
 /// * When running `epic` with defaults, the V2 api is available at
@@ -410,10 +410,7 @@ pub trait ForeignRpc: Sync + Send {
 	```
 	*/
 
-	fn get_last_n_kernels(
-		&self,
-		distance: u64,
-	) -> Result<Vec<TxKernel>, ErrorKind>;
+	fn get_last_n_kernels(&self, distance: u64) -> Result<Vec<TxKernel>, ErrorKind>;
 
 	/**
 	Networked version of [Foreign::get_outputs](struct.Node.html#method.get_outputs).
@@ -867,13 +864,10 @@ impl ForeignRpc for Foreign {
 		));
 	}
 
-	fn get_last_n_kernels(
-		&self,
-		distance: u64,
-	) -> Result<Vec<TxKernel>, ErrorKind>{
+	fn get_last_n_kernels(&self, distance: u64) -> Result<Vec<TxKernel>, ErrorKind> {
 		match Foreign::get_last_n_kernels(self, distance) {
 			Ok(k) => Ok(k),
-			Err(k) => Err(ErrorKind::Argument("Could not get kernels".to_string()))
+			Err(_) => Err(ErrorKind::Argument("Could not get kernels".to_string())),
 		}
 	}
 

--- a/api/src/web.rs
+++ b/api/src/web.rs
@@ -144,7 +144,7 @@ macro_rules! right_path_element(
 		match $req.uri().path().trim_end_matches('/').rsplit('/').next() {
 			None => return response(StatusCode::BAD_REQUEST, "invalid url"),
 			Some(el) => el,
-		};
+		}
 	));
 
 #[macro_export]

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1534,11 +1534,11 @@ fn setup_head(
 					kernel_sum,
 				};
 			}
-			txhashset::header_extending(header_pmmr, &tip, &mut batch, |ext, batch| {
+			txhashset::header_extending(header_pmmr, &tip, &mut batch, |ext, _batch| {
 				ext.apply_header(&genesis.header)?;
 				Ok(())
 			})?;
-			txhashset::header_extending(sync_pmmr, &tip, &mut batch, |ext, batch| {
+			txhashset::header_extending(sync_pmmr, &tip, &mut batch, |ext, _batch| {
 				ext.apply_header(&genesis.header)?;
 				Ok(())
 			})?;

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -18,7 +18,7 @@
 #![deny(non_camel_case_types)]
 #![deny(non_snake_case)]
 #![deny(unused_mut)]
-#![warn(missing_docs)]
+//#![warn(missing_docs)]
 
 #[macro_use]
 extern crate bitflags;

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -27,11 +27,11 @@ use crate::store;
 use crate::store::BottleIter;
 use crate::txhashset;
 use crate::types::{CommitPos, Options, Tip};
-use crate::util::RwLock;
 use chrono::prelude::Utc;
 use chrono::Duration;
 use epic_store;
-use std::sync::Arc;
+//use std::sync::Arc;
+//use crate::util::RwLock;
 
 /// Contextual information required to process a new block and either reject or
 /// accept it.
@@ -394,7 +394,7 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext<'_>) -> Result<(
 		return Err(ErrorKind::PolicyIsNotAllowed.into());
 	}
 
-	if let Some(p) = global::get_policies(header.policy) {
+	if let Some(_p) = global::get_policies(header.policy) {
 		let cursor = BottleIter::from_batch(prev.hash(), &ctx.batch, header.policy);
 		let (algo, _) = consensus::next_policy(header.policy, cursor);
 

--- a/chain/src/txhashset/rewindable_kernel_view.rs
+++ b/chain/src/txhashset/rewindable_kernel_view.rs
@@ -19,8 +19,8 @@ use std::fs::File;
 use crate::core::core::pmmr::RewindablePMMR;
 use crate::core::core::{BlockHeader, TxKernel};
 use crate::error::{Error, ErrorKind};
-use crate::store::Batch;
 use epic_store::pmmr::PMMRBackend;
+//use crate::store::Batch;
 
 /// Rewindable (but readonly) view of the kernel set (based on kernel MMR).
 pub struct RewindableKernelView<'a> {
@@ -34,10 +34,7 @@ impl<'a> RewindableKernelView<'a> {
 		pmmr: RewindablePMMR<'a, TxKernel, PMMRBackend<TxKernel>>,
 		header: BlockHeader,
 	) -> RewindableKernelView<'a> {
-		RewindableKernelView {
-			pmmr,
-			header,
-		}
+		RewindableKernelView { pmmr, header }
 	}
 
 	/// Rewind this readonly view to a previous block.

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -24,9 +24,8 @@ use crate::core::block::feijoada::{
 use crate::core::block::HeaderVersion;
 use crate::core::hash::{Hash, ZERO_HASH};
 use crate::global;
-use crate::pow::{Difficulty, DifficultyNumber, PoWType};
+use crate::pow::{Difficulty, PoWType};
 use std::cmp::{max, min};
-use std::collections::HashMap;
 
 /// A epic is divisible to 10^8 like bitcoin
 pub const EPIC_BASE: u64 = 100_000_000;
@@ -563,11 +562,11 @@ where
 	(pow_type, b)
 }
 
-macro_rules! error_invalid_pow {
+/*macro_rules! error_invalid_pow {
 	($pow:expr) => {
 		panic!("The function next_hash_difficulty is only used by Progpow and RandomX, but it got a {:?}", $pow);
 	}
-}
+}*/
 
 /// Computes the proof-of-work difficulty that the next block should comply
 /// with. Takes an iterator over past block headers information, from latest
@@ -633,7 +632,7 @@ where
 }
 
 /// calculates the next difficulty level for cuckoo
-fn next_cuckoo_difficulty(height: u64, pow: PoWType, diff_data: &Vec<HeaderInfo>) -> u64 {
+fn next_cuckoo_difficulty(_height: u64, pow: PoWType, diff_data: &Vec<HeaderInfo>) -> u64 {
 	// Get the timestamp delta across the window
 
 	let ts_delta: u64 =

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -16,21 +16,18 @@
 
 pub mod feijoada;
 
-use crate::util::RwLock;
-use chrono::naive::{MAX_DATE, MIN_DATE};
+use chrono;
 use chrono::prelude::{DateTime, NaiveDateTime, Utc};
 use chrono::Duration;
 use keccak_hash::keccak_256;
-use std::collections::HashMap;
 use std::collections::HashSet;
 use std::convert::TryInto;
 use std::fmt;
 use std::iter::FromIterator;
-use std::sync::Arc;
 
 use crate::consensus::{
-	self, add_reward_foundation, is_foundation_height, reward, reward_at_height, reward_foundation,
-	total_overage_at_height,
+	self, add_reward_foundation, is_foundation_height, /*reward,*/ reward_at_height,
+	reward_foundation, total_overage_at_height,
 };
 use crate::core::block::feijoada::{get_bottles_default, Policy};
 use crate::core::committed::{self, Committed};
@@ -134,7 +131,7 @@ pub struct HeaderEntry {
 }
 
 impl Readable for HeaderEntry {
-	fn read(reader: &mut Reader) -> Result<HeaderEntry, ser::Error> {
+	fn read(reader: &mut dyn Reader) -> Result<HeaderEntry, ser::Error> {
 		let hash = Hash::read(reader)?;
 		let timestamp = reader.read_u64()?;
 		let total_difficulty = Difficulty::read(reader)?;
@@ -254,7 +251,10 @@ impl Default for BlockHeader {
 		BlockHeader {
 			version: HeaderVersion::default(),
 			height: 0,
-			timestamp: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
+			timestamp: DateTime::<Utc>::from_utc(
+				NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+				Utc,
+			),
 			prev_hash: ZERO_HASH,
 			prev_root: ZERO_HASH,
 			output_root: ZERO_HASH,
@@ -318,8 +318,16 @@ fn read_block_header(reader: &mut dyn Reader) -> Result<BlockHeader, ser::Error>
 	let policy = reader.read_u8()?;
 	let bottles = Policy::read(reader)?;
 
-	if timestamp > MAX_DATE.and_hms(0, 0, 0).timestamp()
-		|| timestamp < MIN_DATE.and_hms(0, 0, 0).timestamp()
+	if timestamp
+		> chrono::NaiveDate::MAX
+			.and_hms_opt(0, 0, 0)
+			.unwrap()
+			.timestamp()
+		|| timestamp
+			< chrono::NaiveDate::MIN
+				.and_hms_opt(0, 0, 0)
+				.unwrap()
+				.timestamp()
 	{
 		return Err(ser::Error::CorruptedData);
 	}
@@ -335,7 +343,10 @@ fn read_block_header(reader: &mut dyn Reader) -> Result<BlockHeader, ser::Error>
 	Ok(BlockHeader {
 		version,
 		height,
-		timestamp: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(timestamp, 0), Utc),
+		timestamp: DateTime::<Utc>::from_utc(
+			NaiveDateTime::from_timestamp_opt(timestamp, 0).unwrap(),
+			Utc,
+		),
 		prev_hash,
 		prev_root,
 		output_root,
@@ -673,7 +684,8 @@ impl Block {
 		let version = consensus::header_version(height);
 
 		let now = Utc::now().timestamp();
-		let timestamp = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(now, 0), Utc);
+		let timestamp =
+			DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp_opt(now, 0).unwrap(), Utc);
 
 		// Now build the block with all the above information.
 		// Note: We have not validated the block here.
@@ -722,7 +734,8 @@ impl Block {
 
 		let height = prev.height + 1;
 		let now = Utc::now().timestamp();
-		let timestamp = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(now, 0), Utc);
+		let timestamp =
+			DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp_opt(now, 0).unwrap(), Utc);
 
 		// Now build the block with all the above information.
 		// Note: We have not validated the block here.

--- a/core/src/core/block/feijoada.rs
+++ b/core/src/core/block/feijoada.rs
@@ -404,14 +404,14 @@ impl Readable for Policy {
 	}
 }
 
-fn largest_allotment(policy: &Policy) -> PoWType {
+/*fn largest_allotment(policy: &Policy) -> PoWType {
 	let (algo, _) = policy.iter().max_by(|&(_, x), &(_, y)| x.cmp(y)).unwrap();
 	*algo
 }
 
 fn check_policy(policy: &Policy) {
 	assert_eq!(100, policy.values().fold(0, |acc, &x| x + acc));
-}
+}*/
 
 pub fn count_beans(bottles: &Policy) -> u32 {
 	std::cmp::max(bottles.values().fold(0, |acc, &x| x + acc), 1)

--- a/core/src/core/committed.rs
+++ b/core/src/core/committed.rs
@@ -125,7 +125,7 @@ pub trait Committed {
 		&self,
 		overage: i64,
 		kernel_offset: BlindingFactor,
-	) -> Result<((Commitment, Commitment)), Error> {
+	) -> Result<(Commitment, Commitment), Error> {
 		// Sum all input|output|overage commitments.
 		let utxo_sum = self.sum_commitments(overage)?;
 

--- a/core/src/core/foundation.rs
+++ b/core/src/core/foundation.rs
@@ -1,4 +1,6 @@
-use crate::consensus::{first_fork_height, foundation_height, foundation_index, header_version};
+use crate::consensus::{
+	/*first_fork_height, foundation_height,*/ foundation_index, header_version,
+};
 use crate::core::{HeaderVersion, Output, TxKernel};
 use crate::global::get_foundation_path;
 use crate::keychain::Identifier;
@@ -60,7 +62,7 @@ fn get_foundation_tx_version_size(version: HeaderVersion) -> usize {
 	}
 }
 
-fn get_foundation_tx_offset(index: u64, version: HeaderVersion) -> u64 {
+fn get_foundation_tx_offset(index: u64, _version: HeaderVersion) -> u64 {
 	let size = index * (FOUNDATION_COINBASE_SIZE_1 as u64);
 
 	if cfg!(windows) {

--- a/core/src/core/pmmr/backend.rs
+++ b/core/src/core/pmmr/backend.rs
@@ -53,7 +53,7 @@ pub trait Backend<T: PMMRable> {
 	fn get_data_from_file(&self, position: u64) -> Option<T::E>;
 
 	/// Iterator over current (unpruned, unremoved) leaf positions.
-	fn leaf_pos_iter(&self) -> Box<Iterator<Item = u64> + '_>;
+	fn leaf_pos_iter(&self) -> Box<dyn Iterator<Item = u64> + '_>;
 
 	/// Number of leaves
 	fn n_unpruned_leaves(&self) -> u64;

--- a/core/src/core/pmmr/rewindable_pmmr.rs
+++ b/core/src/core/pmmr/rewindable_pmmr.rs
@@ -50,7 +50,7 @@ where
 	}
 
 	/// Reference to the underlying storage backend.
-	pub fn backend(&'a self) -> &Backend<T> {
+	pub fn backend(&'a self) -> &dyn Backend<T> {
 		self.backend
 	}
 

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -27,13 +27,13 @@ use keychain::{self, BlindingFactor};
 use std::cmp::Ordering;
 use std::cmp::{max, min};
 use std::convert::TryInto;
-use std::sync::Arc;
+//use std::sync::Arc;
 use std::{error, fmt};
 use util;
 use util::secp;
 use util::secp::pedersen::{Commitment, RangeProof};
 use util::static_secp_instance;
-use util::RwLock;
+//use util::RwLock;
 
 /// Various tx kernel variants.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -24,10 +24,10 @@ use crate::core::block::feijoada::get_bottles_default;
 use crate::global;
 use crate::pow::PoWType;
 use crate::pow::{Difficulty, DifficultyNumber, Proof, ProofOfWork};
-use crate::util;
-use crate::util::secp::constants::SINGLE_BULLET_PROOF_SIZE;
-use crate::util::secp::pedersen::{Commitment, RangeProof};
-use crate::util::secp::Signature;
+//use crate::util;
+//use crate::util::secp::constants::SINGLE_BULLET_PROOF_SIZE;
+//use crate::util::secp::pedersen::{Commitment, RangeProof};
+//use crate::util::secp::Signature;
 
 use crate::core::hash::Hash;
 use crate::keychain::BlindingFactor;
@@ -40,7 +40,7 @@ pub fn genesis_dev() -> core::Block {
 		height: 0,
 		version: core::HeaderVersion(6),
 		// previous: core::hash::Hash([0xff; 32]),
-		timestamp: Utc.ymd(1997, 8, 4).and_hms(0, 0, 0),
+		timestamp: Utc.with_ymd_and_hms(1997, 8, 4, 0, 0, 0).unwrap(),
 		pow: ProofOfWork {
 			nonce: global::get_genesis_nonce(),
 			..Default::default()
@@ -65,7 +65,7 @@ pub fn genesis_floo() -> core::Block {
 	core::Block::with_header(core::BlockHeader {
 		version: core::HeaderVersion(6),
 		height: 0,
-		timestamp: Utc.ymd(2019, 8, 9).and_hms(17, 04, 38),
+		timestamp: Utc.with_ymd_and_hms(2019, 8, 9, 17, 04, 38).unwrap(),
 		prev_root: Hash::from_hex(
 			"00000000000000000017ff4903ef366c8f62e3151ba74e41b8332a126542f538",
 		)
@@ -126,7 +126,7 @@ pub fn genesis_main() -> core::Block {
 	core::Block::with_header(core::BlockHeader {
 		version: core::HeaderVersion(6),
 		height: 0,
-		timestamp: Utc.ymd(2019, 8, 9).and_hms(17, 04, 38),
+		timestamp: Utc.with_ymd_and_hms(2019, 8, 9, 17, 04, 38).unwrap(),
 		prev_root: Hash::from_hex(
 			"00000000000000000004de683e7aa4d35c51f46ec76c6852b0f3161bd1e2e00e",
 		)

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -20,18 +20,18 @@ use crate::consensus;
 use crate::consensus::HeaderInfo;
 use crate::consensus::{
 	graph_weight, BASE_EDGE_BITS, BLOCK_TIME_SEC, COINBASE_MATURITY, CUT_THROUGH_HORIZON,
-	DAY_HEIGHT, DEFAULT_MIN_EDGE_BITS, DIFFICULTY_ADJUST_WINDOW, INITIAL_DIFFICULTY,
+	DAY_HEIGHT, DEFAULT_MIN_EDGE_BITS, /*DIFFICULTY_ADJUST_WINDOW,*/ INITIAL_DIFFICULTY,
 	MAX_BLOCK_WEIGHT, PROOFSIZE, SECOND_POW_EDGE_BITS, STATE_SYNC_THRESHOLD,
 };
 use crate::core::block::feijoada::{AllowPolicy, Policy, PolicyConfig};
-use crate::pow::{self, new_cuckaroo_ctx, new_cuckatoo_ctx, EdgeType, PoWContext};
+use crate::pow::{self, /*new_cuckaroo_ctx,*/ new_cuckatoo_ctx, EdgeType, PoWContext};
 /// An enum collecting sets of parameters used throughout the
 /// code wherever mining is needed. This should allow for
 /// different sets of parameters for different purposes,
 /// e.g. CI, User testing, production values
 use crate::util::RwLock;
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+//use std::collections::HashMap;
 use std::env;
 use std::fs::File;
 use std::path::Path;
@@ -246,7 +246,12 @@ pub fn use_alternative_path(path_str: String) -> String {
 		"Failed to get the executable's directory and no path to the foundation.json was provided!",
 	);
 	//if we run the "cargo test --release" the p contains "cucumber_..." in last folder
-	if p.file_stem().unwrap().to_str().unwrap().contains(&"cucumber") {
+	if p.file_stem()
+		.unwrap()
+		.to_str()
+		.unwrap()
+		.contains(&"cucumber")
+	{
 		return path_str;
 	}
 	//removing the file from the path and going back 2 directories
@@ -313,16 +318,16 @@ pub fn get_allowed_policies() -> Vec<AllowPolicy> {
 }
 
 pub fn get_emitted_policy(height: u64) -> u8 {
-	let policy_config = POLICY_CONFIG.read();
-	if (height <= consensus::BLOCK_ERA_1) {
+	let _policy_config = POLICY_CONFIG.read();
+	if height <= consensus::BLOCK_ERA_1 {
 		0
-	} else if (height <= consensus::BLOCK_ERA_2) {
+	} else if height <= consensus::BLOCK_ERA_2 {
 		1
-	} else if (height <= consensus::BLOCK_ERA_3) {
+	} else if height <= consensus::BLOCK_ERA_3 {
 		2
-	} else if (height <= consensus::BLOCK_ERA_4) {
+	} else if height <= consensus::BLOCK_ERA_4 {
 		3
-	} else if (height <= consensus::BLOCK_ERA_5) {
+	} else if height <= consensus::BLOCK_ERA_5 {
 		4
 	} else {
 		5

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -19,7 +19,7 @@
 #![deny(non_camel_case_types)]
 #![deny(non_snake_case)]
 #![deny(unused_mut)]
-#![warn(missing_docs)]
+//#![warn(missing_docs)]
 
 use blake2;
 extern crate bigint;

--- a/core/src/libtx/mod.rs
+++ b/core/src/libtx/mod.rs
@@ -19,7 +19,7 @@
 #![deny(non_camel_case_types)]
 #![deny(non_snake_case)]
 #![deny(unused_mut)]
-#![warn(missing_docs)]
+//#![warn(missing_docs)]
 
 pub mod aggsig;
 pub mod build;

--- a/core/src/pow.rs
+++ b/core/src/pow.rs
@@ -26,7 +26,7 @@
 #![deny(non_camel_case_types)]
 #![deny(non_snake_case)]
 #![deny(unused_mut)]
-#![warn(missing_docs)]
+//#![warn(missing_docs)]
 
 use chrono;
 use num;
@@ -144,7 +144,8 @@ pub fn pow_size(
 		// and if we're back where we started, update the time (changes the hash as
 		// well)
 		if bh.pow.nonce == start_nonce {
-			bh.timestamp = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc);
+			bh.timestamp =
+				DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc);
 		}
 	}
 }

--- a/core/src/pow/cuckaroo.rs
+++ b/core/src/pow/cuckaroo.rs
@@ -23,7 +23,7 @@
 //! In Cuckaroo, edges are calculated by repeatedly hashing the seeds to
 //! obtain blocks of values. Nodes are then extracted from those edges.
 
-use crate::global;
+//use crate::global;
 use crate::pow::common::{CuckooParams, EdgeType};
 use crate::pow::error::{Error, ErrorKind};
 use crate::pow::siphash::siphash_block;
@@ -59,7 +59,7 @@ where
 		&mut self,
 		header: Vec<u8>,
 		nonce: Option<u64>,
-		height: Option<u64>,
+		_height: Option<u64>,
 		_solve: bool,
 	) -> Result<(), Error> {
 		self.params.reset_header_nonce(header, nonce)

--- a/core/src/pow/cuckatoo.rs
+++ b/core/src/pow/cuckatoo.rs
@@ -17,7 +17,7 @@ use std::mem;
 use byteorder::{BigEndian, WriteBytesExt};
 use croaring::Bitmap;
 
-use crate::global;
+//use crate::global;
 use crate::pow::common::{CuckooParams, EdgeType, Link};
 use crate::pow::error::{Error, ErrorKind};
 use crate::pow::{PoWContext, Proof};
@@ -190,7 +190,7 @@ where
 		&mut self,
 		header: Vec<u8>,
 		nonce: Option<u64>,
-		height: Option<u64>,
+		_height: Option<u64>,
 		solve: bool,
 	) -> Result<(), Error> {
 		self.set_header_nonce_impl(header, nonce, solve)

--- a/core/src/pow/md5.rs
+++ b/core/src/pow/md5.rs
@@ -1,8 +1,8 @@
 //! Implementation of MD5 by Yuri Albuquerque
-use crate::pow::common::{EdgeType, Link};
+use crate::pow::common::EdgeType;
 use crate::pow::error::{Error, ErrorKind};
 use crate::pow::{PoWContext, Proof};
-use crate::util;
+//use crate::util;
 use std::marker::PhantomData;
 
 pub struct MD5Context<T>
@@ -43,7 +43,7 @@ where
 		&mut self,
 		header: Vec<u8>,
 		nonce: Option<u64>,
-		height: Option<u64>,
+		_height: Option<u64>,
 		_solve: bool,
 	) -> Result<(), Error> {
 		self.header = header;

--- a/core/src/pow/progpow.rs
+++ b/core/src/pow/progpow.rs
@@ -2,7 +2,7 @@ extern crate randomx;
 
 use std::marker::PhantomData;
 
-use crate::core::block::BlockHeader;
+//use crate::core::block::BlockHeader;
 use crate::pow::common::EdgeType;
 use crate::pow::error::{Error, ErrorKind};
 use crate::pow::{PoWContext, Proof};
@@ -13,7 +13,7 @@ use keccak_hash::keccak_256;
 use progpow::hardware::cpu::PpCPU;
 use progpow::types::PpCompute;
 
-use bigint::uint::U256;
+//use bigint::uint::U256;
 
 lazy_static! {
 	pub static ref PP_CPU: RwLock<PpCPU> = RwLock::new(PpCPU::new());

--- a/core/src/pow/randomx.rs
+++ b/core/src/pow/randomx.rs
@@ -88,7 +88,7 @@ where
 		&mut self,
 		header: Vec<u8>,
 		nonce: Option<u64>,
-		height: Option<u64>,
+		_height: Option<u64>,
 		_solve: bool,
 	) -> Result<(), Error> {
 		self.header = header;

--- a/core/src/pow/types.rs
+++ b/core/src/pow/types.rs
@@ -29,9 +29,9 @@ use bigint::uint::U256;
 use crate::consensus::{graph_weight, MIN_DIFFICULTY, SECOND_POW_EDGE_BITS};
 use crate::core::hash::{DefaultHashable, Hashed};
 use crate::global;
-use crate::ser::{self, FixedLength, Readable, Reader, Writeable, Writer};
+use crate::ser::{self, /*FixedLength,*/ Readable, Reader, Writeable, Writer};
 
-use crate::core::hash::Hash;
+//use crate::core::hash::Hash;
 use crate::pow::common::EdgeType;
 use crate::pow::error::Error;
 use crate::pow::progpow::get_progpow_value;
@@ -232,9 +232,9 @@ impl fmt::Display for Difficulty {
 
 impl Ord for Difficulty {
 	fn cmp(&self, other: &Self) -> Ordering {
-		let self_sum: u128 = self.num.iter().map(|(x, y)| *y as u128).sum();
+		let self_sum: u128 = self.num.iter().map(|(_x, y)| *y as u128).sum();
 
-		let other_sum: u128 = other.num.iter().map(|(x, y)| *y as u128).sum();
+		let other_sum: u128 = other.num.iter().map(|(_x, y)| *y as u128).sum();
 
 		self_sum.cmp(&other_sum)
 	}
@@ -242,9 +242,9 @@ impl Ord for Difficulty {
 
 impl PartialOrd for Difficulty {
 	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-		let self_sum: u128 = self.num.iter().map(|(x, y)| *y as u128).sum();
+		let self_sum: u128 = self.num.iter().map(|(_x, y)| *y as u128).sum();
 
-		let other_sum: u128 = other.num.iter().map(|(x, y)| *y as u128).sum();
+		let other_sum: u128 = other.num.iter().map(|(_x, y)| *y as u128).sum();
 
 		Some(self_sum.cmp(&other_sum))
 	}
@@ -490,7 +490,7 @@ impl ProofOfWork {
 				}
 			}
 			Proof::RandomXProof { ref hash } => Difficulty::from_proof_hash(hash),
-			Proof::ProgPowProof { ref mix } => {
+			Proof::ProgPowProof { mix: _ } => {
 				Difficulty::from_proof_hash(&get_progpow_value(header, height, nonce))
 			}
 		}

--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -25,7 +25,6 @@ extern crate serde_derive;
 #[macro_use]
 extern crate lazy_static;
 
-#[macro_use]
 extern crate zeroize;
 
 mod base58;

--- a/keychain/src/mnemonic.rs
+++ b/keychain/src/mnemonic.rs
@@ -25,7 +25,7 @@ use std::fmt;
 
 lazy_static! {
 	/// List of bip39 words
-	pub static ref WORDS: Vec<String> = { include_str!("wordlists/en.txt").split_whitespace().map(|s| s.into()).collect() };
+	pub static ref WORDS: Vec<String> = include_str!("wordlists/en.txt").split_whitespace().map(|s| s.into()).collect();
 }
 
 /// An error that might occur during mnemonic decoding

--- a/p2p/src/peers.rs
+++ b/p2p/src/peers.rs
@@ -544,7 +544,7 @@ impl Peers {
 
 		// Delete defunct peers from storage
 		let _ = self.store.delete_peers(|peer| {
-			let diff = now - Utc.timestamp(peer.last_connected, 0);
+			let diff = now - Utc.timestamp_opt(peer.last_connected, 0).unwrap();
 
 			let should_remove = peer.flags == State::Defunct
 				&& diff > Duration::seconds(global::PEER_EXPIRATION_REMOVE_TIME);

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -21,13 +21,13 @@ use self::core::core::transaction;
 use self::core::core::{
 	Block, BlockHeader, BlockSums, Committed, Transaction, TxKernel, Weighting,
 };
-use self::util::RwLock;
 use crate::types::{BlockChain, PoolEntry, PoolError};
 use epic_core as core;
-use epic_util as util;
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+//use self::util::RwLock;
+//use epic_util as util;
 
 pub struct Pool {
 	/// Entries in the pool (tx + info + timer) in simple insertion order.
@@ -38,10 +38,7 @@ pub struct Pool {
 }
 
 impl Pool {
-	pub fn new(
-		chain: Arc<dyn BlockChain>,
-		name: String,
-	) -> Pool {
+	pub fn new(chain: Arc<dyn BlockChain>, name: String) -> Pool {
 		Pool {
 			entries: vec![],
 			blockchain: chain,
@@ -359,10 +356,7 @@ impl Pool {
 					// Otherwise discard and let the next block pick this tx up.
 					let bucket = &tx_buckets[pos];
 
-					if let Ok(new_bucket) = bucket.aggregate_with_tx(
-						entry.tx.clone(),
-						weighting,
-					) {
+					if let Ok(new_bucket) = bucket.aggregate_with_tx(entry.tx.clone(), weighting) {
 						if new_bucket.fee_to_weight >= bucket.fee_to_weight {
 							// Only aggregate if it would not reduce the fee_to_weight ratio.
 							tx_buckets[pos] = new_bucket;

--- a/servers/src/common/stats.rs
+++ b/servers/src/common/stats.rs
@@ -27,7 +27,7 @@ use crate::core::ser::ProtocolVersion;
 
 use chrono::prelude::*;
 
-use crate::chain;
+//use crate::chain;
 use crate::chain::SyncStatus;
 use crate::p2p;
 

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -16,7 +16,7 @@
 use std::convert::From;
 use std::sync::Arc;
 
-use chrono::prelude::{DateTime, Utc};
+use chrono::prelude::Utc;
 use rand::prelude::*;
 
 use crate::api;
@@ -29,7 +29,7 @@ use crate::p2p;
 use crate::pool;
 use crate::pool::types::DandelionConfig;
 use crate::store;
-use crate::util::RwLock;
+//use crate::util::RwLock;
 
 /// Error type wrapping underlying module errors.
 #[derive(Debug)]

--- a/servers/src/epic/server.rs
+++ b/servers/src/epic/server.rs
@@ -51,7 +51,7 @@ use crate::p2p::types::PeerAddr;
 use crate::pool;
 use crate::util::file::get_first_line;
 use crate::util::{RwLock, StopState};
-use clokwerk::{ScheduleHandle, Scheduler, TimeUnits};
+use clokwerk::{/*ScheduleHandle,*/ Scheduler, TimeUnits};
 use epic_util::logger::LogEntry;
 use fs2::FileExt;
 use walkdir::WalkDir;
@@ -387,7 +387,7 @@ impl Server {
 				error!("Unable to get the allowed versions from the dns server!");
 			}
 		});
-		let version_checker_thread = scheduler.watch_thread(Duration::from_millis(100));
+		let _version_checker_thread = scheduler.watch_thread(Duration::from_millis(100));
 
 		warn!("Epic server started.");
 		Ok(Server {
@@ -454,7 +454,7 @@ impl Server {
 		stop_state: Arc<StopState>,
 	) {
 		info!("start_test_miner - start",);
-		let sync_state = self.sync_state.clone();
+		let _sync_state = self.sync_state.clone();
 		let config_wallet_url = match wallet_listener_url.clone() {
 			Some(u) => u,
 			None => String::from("http://127.0.0.1:13415"),

--- a/servers/src/lib.rs
+++ b/servers/src/lib.rs
@@ -19,7 +19,7 @@
 #![deny(non_camel_case_types)]
 #![deny(non_snake_case)]
 #![deny(unused_mut)]
-#![warn(missing_docs)]
+//#![warn(missing_docs)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/servers/src/mining/mine_block.rs
+++ b/servers/src/mining/mine_block.rs
@@ -27,12 +27,12 @@ use crate::api;
 use crate::chain;
 use crate::common::types::Error;
 use crate::core::consensus::is_foundation_height;
-use crate::core::core::block::feijoada::{next_block_bottles, Deterministic, Feijoada};
+//use crate::core::core::block::feijoada::{next_block_bottles, Deterministic, Feijoada};
 use crate::core::core::foundation::load_foundation_output;
 pub use crate::core::core::foundation::CbData;
-use crate::core::core::hash::{Hash, Hashed};
-use crate::core::core::{Output, TxKernel};
-use crate::core::global::{get_emitted_policy, get_policies};
+//use crate::core::core::hash::{Hash, Hashed};
+//use crate::core::core::{Output, TxKernel};
+use crate::core::global::get_emitted_policy;
 use crate::core::libtx::ProofBuilder;
 use crate::core::pow::randomx::rx_current_seed_height;
 use crate::core::pow::PoWType;
@@ -190,7 +190,8 @@ fn build_block(
 	b.header.pow.seed = seed_u8;
 	b.header.pow.nonce = thread_rng().gen();
 	b.header.pow.secondary_scaling = difficulty.secondary_scaling;
-	b.header.timestamp = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(now_sec, 0), Utc);
+	b.header.timestamp =
+		DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp_opt(now_sec, 0).unwrap(), Utc);
 	b.header.policy = get_emitted_policy(b.header.height);
 
 	let bottle_cursor = chain.bottles_iter(get_emitted_policy(b.header.height))?;

--- a/servers/src/mining/stratumserver.rs
+++ b/servers/src/mining/stratumserver.rs
@@ -35,7 +35,7 @@ use std::{cmp, thread};
 use crate::chain::{self, SyncState};
 use crate::common::stats::{StratumStats, WorkerStats};
 use crate::common::types::StratumServerConfig;
-use crate::core::core::block::feijoada::{next_block_bottles, Deterministic};
+//use crate::core::core::block::feijoada::{next_block_bottles, Deterministic};
 use crate::core::core::hash::Hashed;
 use crate::core::core::Block;
 use crate::core::pow::{DifficultyNumber, PoWType};
@@ -45,7 +45,7 @@ use crate::mining::mine_block;
 use crate::pool;
 use crate::util;
 
-use bigint::uint::U256;
+//use bigint::uint::U256;
 use epic_core::pow::Proof;
 use epic_core::ser::Writeable;
 
@@ -368,7 +368,7 @@ impl Handler {
 
 	// Handle GETJOBTEMPLATE message
 	fn handle_getjobtemplate(&self, params: Option<Value>) -> Result<Value, RpcError> {
-		let params: JobParams = parse_params(params)?;
+		let _params: JobParams = parse_params(params)?;
 		// Build a JobTemplate from a BlockHeader and return JSON
 		let job_template = self.build_block_template();
 		let response = serde_json::to_value(&job_template).unwrap();
@@ -379,14 +379,14 @@ impl Handler {
 		return Ok(response);
 	}
 
-	fn get_parse_algorithm(&self, algo: &str) -> PoWType {
+	/*fn get_parse_algorithm(&self, algo: &str) -> PoWType {
 		match algo {
 			"cuckoo" => PoWType::Cuckatoo,
 			"randomx" => PoWType::RandomX,
 			"progpow" => PoWType::ProgPow,
 			_ => panic!("algorithm is not supported"),
 		}
-	}
+	}*/
 
 	// Build and return a JobTemplate for mining the current block
 	fn build_block_template(&self) -> JobTemplate {

--- a/servers/src/mining/test_miner.rs
+++ b/servers/src/mining/test_miner.rs
@@ -146,7 +146,7 @@ impl Miner {
 			let head = self.chain.head_header().unwrap();
 			let mut latest_hash = self.chain.head().unwrap().last_block_h;
 
-			let (mut b, block_fees, pow_type) = mine_block::get_block(
+			let (mut b, block_fees, _pow_type) = mine_block::get_block(
 				&self.chain,
 				&self.tx_pool,
 				key_id.clone(),

--- a/src/bin/tui/mining.rs
+++ b/src/bin/tui/mining.rs
@@ -65,13 +65,14 @@ impl StratumWorkerColumn {
 
 impl TableViewItem<StratumWorkerColumn> for WorkerStats {
 	fn to_column(&self, column: StratumWorkerColumn) -> String {
-		let naive_datetime = NaiveDateTime::from_timestamp(
+		let naive_datetime = NaiveDateTime::from_timestamp_opt(
 			self.last_seen
 				.duration_since(time::UNIX_EPOCH)
 				.unwrap()
 				.as_secs() as i64,
 			0,
-		);
+		)
+		.unwrap();
 		let datetime: DateTime<Utc> = DateTime::from_utc(naive_datetime, Utc);
 
 		match column {
@@ -129,7 +130,7 @@ impl DiffColumn {
 
 impl TableViewItem<DiffColumn> for DiffBlock {
 	fn to_column(&self, column: DiffColumn) -> String {
-		let naive_datetime = NaiveDateTime::from_timestamp(self.time as i64, 0);
+		let naive_datetime = NaiveDateTime::from_timestamp_opt(self.time as i64, 0).unwrap();
 		let datetime: DateTime<Utc> = DateTime::from_utc(naive_datetime, Utc);
 		let pow_type = self.algorithm.clone();
 		match column {

--- a/src/bin/tui/peers.rs
+++ b/src/bin/tui/peers.rs
@@ -101,7 +101,7 @@ impl TableViewItem<PeerColumn> for PeerStats {
 			let other_sum = other_recv_bytes + other_sent_bytes;
 
 			curr_sum.cmp(&other_sum)
-		};
+		}
 
 		let sort_by_addr = || self.addr.cmp(&other.addr);
 

--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -25,7 +25,7 @@ use crate::tui::constants::VIEW_BASIC_STATUS;
 use crate::tui::types::TUIStatusListener;
 
 use crate::chain::SyncStatus;
-use crate::core::pow::{DifficultyNumber, PoWType};
+use crate::core::pow::PoWType;
 use crate::servers::ServerStats;
 
 const NANO_TO_MILLIS: f64 = 1.0 / 1_000_000.0;

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -19,7 +19,7 @@
 #![deny(non_camel_case_types)]
 #![deny(non_snake_case)]
 #![deny(unused_mut)]
-#![warn(missing_docs)]
+//#![warn(missing_docs)]
 
 #[macro_use]
 extern crate log;
@@ -27,8 +27,6 @@ extern crate log;
 extern crate lazy_static;
 #[macro_use]
 extern crate serde_derive;
-#[macro_use]
-extern crate zeroize;
 // Re-export so only has to be included once
 pub use parking_lot::Mutex;
 pub use parking_lot::{RwLock, RwLockReadGuard};


### PR DESCRIPTION
- Most of these address unused code, missing documentation, etc.
- However, many deprecated functions needed replaced in chrono::NaiveDate. This has been done for all applicable locations
- Some warnings still present, but those can be dealt with later

Only warnings left when compiling (rust 1.60)  are as follows: 

```
warning: use of deprecated associated function `zip::ZipWriter::<W>::start_file_from_path`: by stripping `..`s from the path, the meaning of paths can change. Use `start_file` instead.
  --> util/src/zip.rs:43:21
   |
43 |             writer.get_mut().start_file_from_path(x, options)?;
   |                              ^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: use of deprecated associated function `zip::read::ZipFile::<'a>::sanitized_name`: by stripping `..`s from the path, the meaning of paths can change.
                         `mangled_name` can be used if this behaviour is desirable
  --> util/src/zip.rs:63:31
   |
63 |                 let path = dest.join(file.sanitized_name());
   |                                           ^^^^^^^^^^^^^^

warning: use of deprecated associated function `zip::read::ZipFile::<'a>::sanitized_name`: by stripping `..`s from the path, the meaning of paths can change.
                         `mangled_name` can be used if this behaviour is desirable
   --> util/src/zip.rs:151:24
    |
151 |             let san_name = file.sanitized_name();
    |                                 ^^^^^^^^^^^^^^

warning: `epic_util` (lib) generated 3 warnings
warning: use of deprecated associated function `std::error::Error::description`: use the Display impl or to_string()
   --> keychain/src/extkey_bip32.rs:338:41
    |
338 |             Error::Ecdsa(ref e) => error::Error::description(e),
    |                                                  ^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: `epic_keychain` (lib) generated 1 warning
warning: unused doc comment
  --> core/src/core/id.rs:77:1
   |
77 | / /// We want to sort short_ids in a canonical and consistent manner so we can
78 | | /// verify sort order in the same way we do for full inputs|outputs|kernels
79 | | /// themselves.
   | |_--------------^
   |   |
   |   rustdoc does not generate documentation for macro invocations
   |
   = note: `#[warn(unused_doc_comments)]` on by default
   = help: to document an item produced by a macro, the macro must produce the documentation as part of its expansion

warning: use of deprecated associated function `std::error::Error::description`: use the Display impl or to_string()
  --> core/src/core/foundation.rs:50:68
   |
50 |         Err(why) => panic!("Couldn't create {}: {}", path.display(), why.description()),
   |                                                                          ^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: `epic_core` (lib) generated 2 warnings
   Compiling epic v3.4.0 (/home/biz/EpicCash/epic-warnings)
warning: value assigned to `prev_header` is never read
   --> chain/src/store.rs:516:14
    |
516 |                     let mut prev_header = None;
    |                             ^^^^^^^^^^^
    |
    = note: `#[warn(unused_assignments)]` on by default
    = help: maybe it is overwritten before being read?

warning: value assigned to `prev_header` is never read
   --> chain/src/store.rs:759:14
    |
759 |                     let mut prev_header = None;
    |                             ^^^^^^^^^^^
    |
    = help: maybe it is overwritten before being read?

warning: `epic_chain` (lib) generated 2 warnings
warning: use of deprecated struct `cursive::view::ScrollBase`: `ScrollBase` is being deprecated in favor of the view::scroll module.
  --> src/bin/tui/table.rs:70:21
   |
70 | use cursive::view::{ScrollBase, View};
   |                     ^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: use of deprecated struct `cursive::view::ScrollBase`: `ScrollBase` is being deprecated in favor of the view::scroll module.
   --> src/bin/tui/table.rs:150:14
    |
150 |     scrollbase: ScrollBase,
    |                 ^^^^^^^^^^

warning: use of deprecated struct `cursive::view::ScrollBase`: `ScrollBase` is being deprecated in favor of the view::scroll module.
   --> src/bin/tui/table.rs:176:16
    |
176 |             scrollbase: ScrollBase::new(),
    |                         ^^^^^^^^^^

warning: variant is never constructed: `PowDifficulty`
  --> src/bin/tui/mining.rs:44:2
   |
44 |     PowDifficulty,
   |     ^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default
note: `StratumWorkerColumn` has a derived impl for the trait `Clone`, but this is intentionally ignored during dead code analysis
  --> src/bin/tui/mining.rs:39:16
   |
39 | #[derive(Copy, Clone, PartialEq, Eq, Hash)]
   |                ^^^^^
   = note: this warning originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: variant is never constructed: `SecondaryScaling`
   --> src/bin/tui/mining.rs:111:2
    |
111 |     SecondaryScaling,
    |     ^^^^^^^^^^^^^^^^
    |
note: `DiffColumn` has a derived impl for the trait `Clone`, but this is intentionally ignored during dead code analysis
   --> src/bin/tui/mining.rs:105:16
    |
105 | #[derive(Copy, Clone, PartialEq, Eq, Hash)]
    |                ^^^^^
    = note: this warning originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: `epic` (bin "epic") generated 5 warnings

```