### PR TITLE
Add checkpoints, and ability to skip PoW check in range

### DIFF
--- a/chain/src/error.rs
+++ b/chain/src/error.rs
@@ -159,6 +159,9 @@ pub enum ErrorKind {
 
 	#[fail(display = "Invalid seed")]
 	InvalidSeed,
+
+	#[fail(display = "Checkpoint Integrity Failure: Mismatched hashes")]
+	CheckpointFailure,
 }
 
 impl Display for Error {

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -1,3 +1,4 @@
+// Copyright 2019-2023, Epic Cash Developers
 // Copyright 2018 The Grin Developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -409,4 +410,108 @@ pub enum BlockStatus {
 	/// Block updates the chain head via a (potentially disruptive) "reorg".
 	/// Previous block was not our previous chain head.
 	Reorg(u64),
+}
+
+// Elements in checkpoint data vector
+#[derive(Debug)]
+pub struct Checkpoint {
+	pub height: u64,
+	pub block_hash: Hash,
+}
+
+#[derive(Debug)]
+pub struct BlockchainCheckpoints {
+	pub checkpoints: Vec<Checkpoint>,
+}
+
+impl BlockchainCheckpoints {
+	pub fn new() -> BlockchainCheckpoints {
+		let checkpoints = vec![
+			Checkpoint {
+				height: 100000,
+				block_hash: Hash::from_hex(
+					"e835eb9ebc9f2e13b11061691cb268f44b20001f081003169b634497eb730848",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 200000,
+				block_hash: Hash::from_hex(
+					"b2365a8c9719a709f11d450bbddfd012011e21c862239bdc8590aba00815e84c",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 400000,
+				block_hash: Hash::from_hex(
+					"6578f1cdf5504d29fc757424e75ac60494e0f6d24b7553d124c8bea6ef99b5d8",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 600000,
+				block_hash: Hash::from_hex(
+					"de483eafb2141d66bf541a94d8e41858f01ffc517b9fa61d8781483c34c2a6f7",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 800000,
+				block_hash: Hash::from_hex(
+					"1465e7c094376e781b1e80ebd6b7a0c6350ec4d6554f9acdd843802162831003",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 1000000,
+				block_hash: Hash::from_hex(
+					"00e4a404130ac192face23fd25f2c46a99a38a31d8cf2d3cc79ea7a518830686",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 1200000,
+				block_hash: Hash::from_hex(
+					"8d69282df5579d32346ad0f6d3f4e03a43b1e00e741b1f3ba71c2934d81e5e1a",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 1400000,
+				block_hash: Hash::from_hex(
+					"e7e34e50e8a5c9bcf3fe7b7ad99e62a848cda37171ce8d37f21bc334035df4d2",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 1600000,
+				block_hash: Hash::from_hex(
+					"ba44beaf37776c3e7da3f4a1b906ae238e1178794cbaa90685e3945d2662d7a2",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 1800000,
+				block_hash: Hash::from_hex(
+					"4f23aaf2e83e4041cac670226d3024f4468e3b9bb6ffa2548ebc59489bd09b63",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 2000000,
+				block_hash: Hash::from_hex(
+					"eaf5d7a4b6f07ccb8bdbe5db2f39e10eea3ee1c28f8333907d91c9ccc21ce99d",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 2050000,
+				block_hash: Hash::from_hex(
+					"1a51bb18562e120f33783e53a70c449fd14197ac77082dc23d664c7f47a744c9",
+				)
+				.unwrap(),
+			},
+		];
+		return BlockchainCheckpoints { checkpoints };
+	}
 }

--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -104,6 +104,15 @@ fn comments() -> HashMap<String, String> {
 	);
 
 	retval.insert(
+		"skip_pow_validation".to_string(),
+		"
+#Whether or not to skip pow validation when syncing headers
+#Only applies to blocks within checkpointed history range (default is false)
+"
+		.to_string(),
+	);
+
+	retval.insert(
 		"archive_mode".to_string(),
 		"
 #run the node in \"full archive\" mode (default is fast-sync, pruned node)

--- a/edna.toml
+++ b/edna.toml
@@ -49,6 +49,10 @@ chain_validation_mode = "Disabled"
 #run the node in "full archive" mode (default is fast-sync, pruned node)
 archive_mode = false
 
+#Whether or not to skip pow validation when syncing headers
+#Only applies to blocks within checkpointed history range (default is false)
+skip_pow_validation = false
+
 #skip waiting for sync on startup, (optional param, mostly for testing)
 skip_sync_wait = false
 

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -304,7 +304,15 @@ impl p2p::ChainAdapter for NetToChainAdapter {
 			bhs.len(),
 			peer_info.addr
 		);
-		match self.chain().sync_block_headers(bhs, chain::Options::SYNC) {
+
+		let mut ctx_option = Options::SYNC;
+
+		if self.config.skip_pow_validation.is_some() {
+			if self.config.skip_pow_validation.unwrap() {
+				ctx_option = Options::SKIP_POW;
+			}
+		}
+		match self.chain().sync_block_headers(bhs, ctx_option) {
 			Ok(_) => {
 				info!(
 					"------------ Validation required: {:?} sec ------------",

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -172,6 +172,9 @@ pub struct ServerConfig {
 	/// Whether this node is a full archival node or a fast-sync, pruned node
 	pub archive_mode: Option<bool>,
 
+	// How to validate new block headers
+	pub skip_pow_validation: Option<bool>,
+
 	/// Whether to skip the sync timeout on startup
 	/// (To assist testing on solo chains)
 	pub skip_sync_wait: Option<bool>,
@@ -236,6 +239,7 @@ impl Default for ServerConfig {
 			stratum_mining_config: Some(StratumServerConfig::default()),
 			chain_type: ChainTypes::default(),
 			archive_mode: Some(false),
+			skip_pow_validation: Some(false),
 			chain_validation_mode: ChainValidationMode::default(),
 			pool_config: pool::PoolConfig::default(),
 			skip_sync_wait: Some(false),


### PR DESCRIPTION
- Adds checkpoints every 200k blocks + one at height 2,050,000
- These blocks are checked explicitly for hash integrity
- Once the final checkpoint is reached, remainder of blocks are fully validated for work proof
- Adds 'skip_pow_validation' setting to config, defaults to false