### PR TITLE
Improvements to BodySync portion of Sync phases

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -45,7 +45,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 /// Orphan pool size is limited by MAX_ORPHAN_SIZE
-pub const MAX_ORPHAN_SIZE: usize = 200;
+pub const MAX_ORPHAN_SIZE: usize = 60;
 
 /// When evicting, very old orphans are evicted first
 const MAX_ORPHAN_AGE_SECS: u64 = 300;

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -298,19 +298,18 @@ impl Chain {
 		let header_head = self.header_head()?;
 		let mut loop_orphans = false;
 		if header_head.height > ORPHAN_LOOP_THRESHOLD {
-			debug!(
+			trace!(
 				"loop_height({}), ORPHAN_LOOP_THRESHOLD({}), subtracted({})",
 				loop_height,
 				ORPHAN_LOOP_THRESHOLD,
 				(loop_height - ORPHAN_LOOP_THRESHOLD)
 			);
-			debug!("header_head.height({})", header_head.height);
 			if loop_height >= (header_head.height - ORPHAN_LOOP_THRESHOLD) {
-				debug!("threshold check conditon met!");
+				trace!("threshold check conditon met!");
 				loop_orphans = true;
 			}
 			if self.orphans.len() >= (MAX_ORPHAN_SIZE - 10) {
-				debug!("orphan.len() conditon met!");
+				trace!("orphan.len() conditon met!");
 				loop_orphans = true;
 			}
 		}
@@ -319,7 +318,7 @@ impl Chain {
 			Ok(_) => {
 				orphan_height = block_height + 1;
 				if loop_orphans {
-					debug!("looping through orphans!");
+					trace!("looping through orphans!");
 					self.check_orphans_loop(orphan_height);
 					return res;
 				}
@@ -334,7 +333,7 @@ impl Chain {
 				res = self.process_block_single(orphan.block, orphan.opts);
 			}
 			if loop_orphans && res.is_ok() {
-				warn!("looping through orphans!");
+				trace!("looping through orphans!");
 				self.check_orphans_loop(orphan_height + 1);
 			}
 		}

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -135,11 +135,10 @@ impl OrphanBlockPool {
 	}
 
 	pub fn clear(&self) -> bool {
-		let mut orphans = self.orphans.write();
-		let mut height_idx = self.height_idx.write();
-		orphans.clear();
-		height_idx.clear();
-		return orphans.is_empty() && height_idx.is_empty();
+		self.orphans.write().clear();
+		self.height_idx.write().clear();
+		self.evicted.store(0, Ordering::Relaxed);
+		return self.orphans.read().is_empty() && self.height_idx.read().is_empty();
 	}
 
 	pub fn contains(&self, hash: &Hash) -> bool {
@@ -525,7 +524,7 @@ impl Chain {
 		orphans_result
 	}
 
-	/// Clear OprhanBlockPool completely, returns true if orphans list
+	/// Clear OrphanBlockPool completely, returns true if orphans list
 	/// and height_idx are empty after clearing, false if failed
 	pub fn clear_orphans(&self) -> bool {
 		self.orphans.clear()

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -134,6 +134,14 @@ impl OrphanBlockPool {
 			.map(|hs| hs.iter().filter_map(|h| orphans.remove(h)).collect())
 	}
 
+	pub fn clear(&self) -> bool {
+		let mut orphans = self.orphans.write();
+		let mut height_idx = self.height_idx.write();
+		orphans.clear();
+		height_idx.clear();
+		return orphans.is_empty() && height_idx.is_empty();
+	}
+
 	pub fn contains(&self, hash: &Hash) -> bool {
 		let orphans = self.orphans.read();
 		orphans.contains_key(hash)
@@ -496,6 +504,12 @@ impl Chain {
 			}
 		}
 		orphans_result
+	}
+
+	/// Clear OprhanBlockPool completely, returns true if orphans list
+	/// and height_idx are empty after clearing, false if failed
+	pub fn clear_orphans(&self) -> bool {
+		self.orphans.clear()
 	}
 
 	/// For the given commitment find the unspent output and return the

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -411,3 +411,107 @@ pub enum BlockStatus {
 	/// Previous block was not our previous chain head.
 	Reorg(u64),
 }
+
+// Elements in checkpoint data vector
+#[derive(Debug)]
+pub struct Checkpoint {
+	pub height: u64,
+	pub block_hash: Hash,
+}
+
+#[derive(Debug)]
+pub struct BlockchainCheckpoints {
+	pub checkpoints: Vec<Checkpoint>,
+}
+
+impl BlockchainCheckpoints {
+	pub fn new() -> BlockchainCheckpoints {
+		let checkpoints = vec![
+			Checkpoint {
+				height: 100000,
+				block_hash: Hash::from_hex(
+					"e835eb9ebc9f2e13b11061691cb268f44b20001f081003169b634497eb730848",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 200000,
+				block_hash: Hash::from_hex(
+					"b2365a8c9719a709f11d450bbddfd012011e21c862239bdc8590aba00815e84c",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 400000,
+				block_hash: Hash::from_hex(
+					"6578f1cdf5504d29fc757424e75ac60494e0f6d24b7553d124c8bea6ef99b5d8",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 600000,
+				block_hash: Hash::from_hex(
+					"de483eafb2141d66bf541a94d8e41858f01ffc517b9fa61d8781483c34c2a6f7",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 800000,
+				block_hash: Hash::from_hex(
+					"1465e7c094376e781b1e80ebd6b7a0c6350ec4d6554f9acdd843802162831003",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 1000000,
+				block_hash: Hash::from_hex(
+					"00e4a404130ac192face23fd25f2c46a99a38a31d8cf2d3cc79ea7a518830686",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 1200000,
+				block_hash: Hash::from_hex(
+					"8d69282df5579d32346ad0f6d3f4e03a43b1e00e741b1f3ba71c2934d81e5e1a",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 1400000,
+				block_hash: Hash::from_hex(
+					"e7e34e50e8a5c9bcf3fe7b7ad99e62a848cda37171ce8d37f21bc334035df4d2",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 1600000,
+				block_hash: Hash::from_hex(
+					"ba44beaf37776c3e7da3f4a1b906ae238e1178794cbaa90685e3945d2662d7a2",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 1800000,
+				block_hash: Hash::from_hex(
+					"4f23aaf2e83e4041cac670226d3024f4468e3b9bb6ffa2548ebc59489bd09b63",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 2000000,
+				block_hash: Hash::from_hex(
+					"eaf5d7a4b6f07ccb8bdbe5db2f39e10eea3ee1c28f8333907d91c9ccc21ce99d",
+				)
+				.unwrap(),
+			},
+			Checkpoint {
+				height: 2050000,
+				block_hash: Hash::from_hex(
+					"1a51bb18562e120f33783e53a70c449fd14197ac77082dc23d664c7f47a744c9",
+				)
+				.unwrap(),
+			},
+		];
+		return BlockchainCheckpoints { checkpoints };
+	}
+}

--- a/servers/src/common/adapters.rs
+++ b/servers/src/common/adapters.rs
@@ -131,6 +131,19 @@ where
 		peer_info: &PeerInfo,
 		opts: chain::Options,
 	) -> Result<bool, chain::Error> {
+		// TODO: guard against panic on unwrap, in case someone changes this constant
+		if self.sync_state.is_syncing() {
+			let orphan_size: u64 = chain::MAX_ORPHAN_SIZE.try_into().unwrap();
+			if b.header.height.clone() > (self.chain().head()?.height + (orphan_size * 2)) {
+				debug!(
+					"Ignoring full block {}, height({}), delivered during sync",
+					b.hash(),
+					b.header.height.clone()
+				);
+				return Ok(true);
+			}
+		}
+
 		if self.chain().block_exists(b.hash())? {
 			return Ok(true);
 		}
@@ -151,6 +164,17 @@ where
 		cb: core::CompactBlock,
 		peer_info: &PeerInfo,
 	) -> Result<bool, chain::Error> {
+		if self.sync_state.is_syncing() {
+			let orphan_size: u64 = chain::MAX_ORPHAN_SIZE.try_into().unwrap();
+			if cb.header.height.clone() > (self.chain().head()?.height + (orphan_size * 2)) {
+				debug!(
+					"Ignoring compact block {}, height({}), delivered during sync",
+					cb.hash(),
+					cb.header.height.clone()
+				);
+				return Ok(true);
+			}
+		}
 		// No need to process this compact block if we have previously accepted the _full block_.
 		if self.chain().block_exists(cb.hash())? {
 			return Ok(true);

--- a/servers/src/common/types.rs
+++ b/servers/src/common/types.rs
@@ -21,7 +21,6 @@ use rand::prelude::*;
 
 use crate::api;
 use crate::chain;
-use crate::core::core::hash::Hash;
 use crate::core::global;
 use crate::core::global::ChainTypes;
 use crate::core::{consensus, core, libtx, pow};
@@ -451,109 +450,5 @@ impl DandelionEpoch {
 		}
 
 		self.relay_peer.clone()
-	}
-}
-
-// Elements in checkpoint data vector
-#[derive(Debug)]
-pub struct Checkpoint {
-	pub height: u64,
-	pub block_hash: Hash,
-}
-
-#[derive(Debug)]
-pub struct BlockchainCheckpoints {
-	pub checkpoints: Vec<Checkpoint>,
-}
-
-impl BlockchainCheckpoints {
-	pub fn new() -> BlockchainCheckpoints {
-		let checkpoints = vec![
-			Checkpoint {
-				height: 100000,
-				block_hash: Hash::from_hex(
-					"e835eb9ebc9f2e13b11061691cb268f44b20001f081003169b634497eb730848",
-				)
-				.unwrap(),
-			},
-			Checkpoint {
-				height: 200000,
-				block_hash: Hash::from_hex(
-					"b2365a8c9719a709f11d450bbddfd012011e21c862239bdc8590aba00815e84c",
-				)
-				.unwrap(),
-			},
-			Checkpoint {
-				height: 400000,
-				block_hash: Hash::from_hex(
-					"6578f1cdf5504d29fc757424e75ac60494e0f6d24b7553d124c8bea6ef99b5d8",
-				)
-				.unwrap(),
-			},
-			Checkpoint {
-				height: 600000,
-				block_hash: Hash::from_hex(
-					"de483eafb2141d66bf541a94d8e41858f01ffc517b9fa61d8781483c34c2a6f7",
-				)
-				.unwrap(),
-			},
-			Checkpoint {
-				height: 800000,
-				block_hash: Hash::from_hex(
-					"1465e7c094376e781b1e80ebd6b7a0c6350ec4d6554f9acdd843802162831003",
-				)
-				.unwrap(),
-			},
-			Checkpoint {
-				height: 1000000,
-				block_hash: Hash::from_hex(
-					"00e4a404130ac192face23fd25f2c46a99a38a31d8cf2d3cc79ea7a518830686",
-				)
-				.unwrap(),
-			},
-			Checkpoint {
-				height: 1200000,
-				block_hash: Hash::from_hex(
-					"8d69282df5579d32346ad0f6d3f4e03a43b1e00e741b1f3ba71c2934d81e5e1a",
-				)
-				.unwrap(),
-			},
-			Checkpoint {
-				height: 1400000,
-				block_hash: Hash::from_hex(
-					"e7e34e50e8a5c9bcf3fe7b7ad99e62a848cda37171ce8d37f21bc334035df4d2",
-				)
-				.unwrap(),
-			},
-			Checkpoint {
-				height: 1600000,
-				block_hash: Hash::from_hex(
-					"ba44beaf37776c3e7da3f4a1b906ae238e1178794cbaa90685e3945d2662d7a2",
-				)
-				.unwrap(),
-			},
-			Checkpoint {
-				height: 1800000,
-				block_hash: Hash::from_hex(
-					"4f23aaf2e83e4041cac670226d3024f4468e3b9bb6ffa2548ebc59489bd09b63",
-				)
-				.unwrap(),
-			},
-			Checkpoint {
-				height: 2000000,
-				block_hash: Hash::from_hex(
-					"eaf5d7a4b6f07ccb8bdbe5db2f39e10eea3ee1c28f8333907d91c9ccc21ce99d",
-				)
-				.unwrap(),
-			},
-			Checkpoint {
-				height: 2050000,
-				block_hash: Hash::from_hex(
-					"1a51bb18562e120f33783e53a70c449fd14197ac77082dc23d664c7f47a744c9",
-				)
-				.unwrap(),
-			},
-		];
-		return BlockchainCheckpoints { checkpoints };
 	}
 }

--- a/servers/src/epic/sync/body_sync.rs
+++ b/servers/src/epic/sync/body_sync.rs
@@ -135,15 +135,17 @@ impl BodySync {
 			self.blocks_requested = 0;
 			self.receive_timeout = Utc::now() + Duration::seconds(6);
 
-			let mut peers_iter = peers.iter().cycle();
+			let mut peer_idx = 0;
 			for hash in hashes_to_get.clone() {
-				if let Some(peer) = peers_iter.next() {
-					if let Err(e) = peer.send_block_request(*hash, chain::Options::SYNC) {
-						debug!("Skipped request to {}: {:?}", peer.info.addr, e);
-						peer.stop();
-					} else {
-						self.blocks_requested += 1;
-					}
+				if let Err(e) = peers[peer_idx].send_block_request(*hash, chain::Options::SYNC) {
+					debug!("Skipped request to {}: {:?}", peers[peer_idx].info.addr, e);
+					peers[peer_idx].stop();
+				} else {
+					self.blocks_requested += 1;
+				}
+				peer_idx += 1;
+				if peer_idx == peers.len() {
+					break;
 				}
 			}
 		}

--- a/servers/src/epic/sync/body_sync.rs
+++ b/servers/src/epic/sync/body_sync.rs
@@ -135,17 +135,16 @@ impl BodySync {
 			self.blocks_requested = 0;
 			self.receive_timeout = Utc::now() + Duration::seconds(6);
 
-			let mut peer_idx = 0;
+			let mut peers_iter = peers.iter();
+			//let mut peers_iter = peers.iter().cycle();
 			for hash in hashes_to_get.clone() {
-				if let Err(e) = peers[peer_idx].send_block_request(*hash, chain::Options::SYNC) {
-					debug!("Skipped request to {}: {:?}", peers[peer_idx].info.addr, e);
-					peers[peer_idx].stop();
-				} else {
-					self.blocks_requested += 1;
-				}
-				peer_idx += 1;
-				if peer_idx == peers.len() {
-					break;
+				if let Some(peer) = peers_iter.next() {
+					if let Err(e) = peer.send_block_request(*hash, chain::Options::SYNC) {
+						debug!("Skipped request to {}: {:?}", peer.info.addr, e);
+						peer.stop();
+					} else {
+						self.blocks_requested += 1;
+					}
 				}
 			}
 		}

--- a/servers/src/epic/sync/syncer.rs
+++ b/servers/src/epic/sync/syncer.rs
@@ -423,12 +423,12 @@ impl SyncRunner {
 				_ => {
 					// skip body sync if header chain is not synced.
 					if header_head.height < highest_network_height {
-						warn!(
+						/*warn!(
 							">>> DEFAULT_CASE portion of sync_state, continue case met. header_height({}), highest_network_height({})",
 							header_head.height,
 							highest_network_height
 						);
-						warn!("<<< sync_state({:?})", self.sync_state.status());
+						warn!("<<< sync_state({:?})", self.sync_state.status());*/
 
 						match self.sync_state.status() {
 							SyncStatus::BodySync { .. } => {

--- a/servers/src/epic/sync/syncer.rs
+++ b/servers/src/epic/sync/syncer.rs
@@ -423,6 +423,35 @@ impl SyncRunner {
 				_ => {
 					// skip body sync if header chain is not synced.
 					if header_head.height < highest_network_height {
+						warn!(
+							">>> DEFAULT_CASE portion of sync_state, continue case met. header_height({}), highest_network_height({})",
+							header_head.height,
+							highest_network_height
+						);
+						warn!("<<< sync_state({:?})", self.sync_state.status());
+
+						match self.sync_state.status() {
+							SyncStatus::BodySync { .. } => {
+								download_headers = true;
+								match self.chain.reset_sync_head() {
+									Ok(_) => (),
+									Err(e) => {
+										error!(
+											"Unable to reset sync head, error: {:?}",
+											e.to_string()
+										);
+									}
+								}
+								{
+									if !self.chain.clear_orphans() {
+										error!(
+											"Failed to fully clear ophan hashmap, continuing anyway!"
+										);
+									}
+								} // scope for RwLock
+							}
+							_ => {}
+						}
 						continue;
 					}
 


### PR DESCRIPTION
This PR has a fairly large amount of changes, so we will detail them commit-by-commit below. 

***Cumulatively, the results of these are:***
1. **Dramatically improved sync performance, particularly with respect to BodySync phase**
2. **Much greater granularity for user settings (custom levels of PoW verification)**
3. **More efficient peer comms, as they pertain to `block_sync`**
4. **Better handling of OphanBlockPool, which is a `RwLock<HashMap>` type, to minimize prohibitive locking**
5. **Dynamic thresholds near chaintip to force full verification of short-term blockchain history**

---

**Commit-Wise Summary of Changes:**


**1. Refactor BlockchainCheckpoints code for easier readability https://github.com/EpicCash/epic/commit/929b3e93eb72725e71533bf50511de117efe4b4d**
- This improves upon the [code added here](https://github.com/EpicCash/epic/commit/bcf0ecc75cce8709736f8d3a1f2f68ca4290db82) to allow us to also skip pow verification when syncing block bodies.  Prior commit added a `disable_checkpoints` setting in config file to skip pow checking all the way to chaintip, for block headers in `HeaderSync` phase.  This refactoring makes the checkpoint code available to function in `BodySync` phase as well. It wraps all of this into a `check_header_against_checkpoints` function. 

**2. Add dynamic threshold (wrt to chaintip) for pow checking https://github.com/EpicCash/epic/commit/6ff082566d42ea5112295362ae16758202362bd8**
- Forces full block verification (including resource-intensive PoW checking) for blocks within a pre-defined threshold to chaintip.  Fully verify all blocks within (x) blocks to `max_network_height`.  Later commit makes this "x blocks" value more clear.

**3. Remove looping logic in check_orphans func https://github.com/EpicCash/epic/commit/b3eeb265f7247beab4c0e01fcc7c7658eebd2a83**
- Modifies behavior of `OrphanBlockPool` checking substantially, when receiving new blocks.
- Previously, `check_orphans` was only called when we successfully processed a new block.  Once called, `check_orphans` was looping infinitely until we failed to find an orphan to process next.  This meant the loop in `check_orphans` was executing hundreds of times before `process_block` function exited.
- Now, we check orphan list **once and only once** for each block we receive.  This check occurs whether we can process the received block properly, or not.  Orphan list is checked for either `new_tip_height + 1` on successful process, or `current_tip_height + 1` on unsuccessful processing.

**4. Don't accept new blocks (compact/full) while syncing https://github.com/EpicCash/epic/commit/8ac4e1ecebcb2963918044e9240747a5a29dc3a7**
- Ignores new block or compact block broadcasts while we are syncing, if we are less than `MAX_ORPHAN_SIZE * 2` blocks from chaintip.
- This resolves most printed errors "Block is Unfit at this time", that were visible while syncing

**5. Don't use peers.iter().next() in bodysync https://github.com/EpicCash/epic/commit/eb8e73ec2aca6c85cdd566f0de93d3eabdd32cb7**
- Prior to this change, our 'most_work_peers' list was being cycled.  So if we have 10 connected peers, and need 20 blocks... 
  - The blocks at entry no. 1 and no. 11 would be requested from Peer A
  - 2 and 12 from Peer B
  - 3 and 13 from Peer C, So on, and etc.
- This change ensures we don't make multiple requests to a peer at a single time.  Goal is to lock up our iostreams in peer comms less often, as it appears to be a particularly slow area of code
- Coupled with the smaller `MAX_ORPHAN_SIZE` added in a later commit, this makes peer comms a lot more efficient and less spammy.

**6. Add clear_orphans(), call prior to BodySync->HeaderSync switch back https://github.com/EpicCash/epic/commit/bf3577555958538345984ed9166c1a114e90c0de**
- Adds the ability to switch back to HeaderSync phase, if we are in BodySync and many more blocks are found on network while we are syncing block bodies.  Previously, this state was irrecoverable, and required a node restart to trigger `HeaderSync` again.  Epic nodes will now switch back automatically.
- Adds a `clear_orphans` function, to completely clear OprhanBlockPool.  This function is called ONLY PRIOR to a phase switch to `HeaderSync` from `BodySync` state.  This was done to ensure a clean `BodySync`/`OrphanBlockPool` state when we finish syncing new headers.

**7. use explictly named constants for thresholds in adapters https://github.com/EpicCash/epic/commit/bf3577555958538345984ed9166c1a114e90c0de**
- Provides more readable, explcitly named constants for the dynamic thresholds in prior commits in this PR.
- Adds `POW_VERIFICATION_THRESHOLD = 1000` to force full verification of last 1000 blocks to chaintip
- Adds `BLOCK_BROADCAST_IGNORE_THRESHOLD = 200` to ignore broadcasts of new blocks at chaintip until we are within 200 blocks to chaintip.

**8. Revert commit eb8e73e, was causing deadlock https://github.com/EpicCash/epic/commit/3123e62152dc4c3b5c7f0deedfc4a4d6e87d549b**
- Reverts a small change from the commit mentioned above, which caused a deadlock.  No actual changes in this, respective to our current codebase.  Just reverted those prior changes.
- Peers are still not cycled, and we request 1 block from 1 peer at a time

**9. Merge upstream changes for 'process_block_single' https://github.com/EpicCash/epic/commit/bbbb61014c0c95734ce3ad262c1da4b898b687b8**
- Pulls updated logic (more readable, maybe a small speedup) for `process_block_single` function from upstream Grin codebase
- Adds `check_orphan` function, for adding orphans to OrphanBlockPool
- Adds `is_known` function, for checking if we already know about the block we are attempting to process, exiting function early if so
- Removes unnecessary and hard-to-read code, replacing it instead with Rusts `?` trailing symbol, which exits function early if unsuccessful

**10. Reduce `MAX_ORPHAN_SIZE` to 60 https://github.com/EpicCash/epic/commit/68cc172f90e6e1e986f0e0705517236e0886c994**
- Shortens the maximum length of our LRUCache, to hold only 60 blocks in OrphanBlockPool
- Speeds up our write calls to OrphanBlockPool due to reduced size of data, and makes our `chain::process_block` calls more efficient as a result
- Combined with removal of looping logic in `check_orphans`, speedup is significant when compared to holding 200 entries in our orphan list
- Additionally, speeds up last `MAX_ORPHAN_SIZE` blocks when syncing to chaintip.  This is the one area where things slow down compared to old logic.  Since we no longer unwind our OrphanBlockPool with a loop, orphan list will be cleared 1-by-1 as we approach chaintip.  Last `MAX_ORPHAN_SIZE` blocks are synced as fast as we receive new block protocol messages from peers, as we only process one orphan with each received block now.
