### PR TITLE
Remove usage of deprecated 'description' in errors

### DIFF
--- a/core/src/core/foundation.rs
+++ b/core/src/core/foundation.rs
@@ -6,7 +6,6 @@ use crate::global::get_foundation_path;
 use crate::keychain::Identifier;
 use crate::serde::{Deserialize, Serialize};
 use serde_json;
-use std::error::Error;
 use std::fs::{create_dir, File};
 use std::io::prelude::*;
 use std::io::SeekFrom;
@@ -49,7 +48,7 @@ pub fn save_in_disk(serialization: String, path: &Path) {
 	path = path.join("foundation.json");
 	println!("Saving the file as: {}", path.display());
 	let mut file = match File::create(&path) {
-		Err(why) => panic!("Couldn't create {}: {}", path.display(), why.description()),
+		Err(why) => panic!("Couldn't create {}: {}", path.display(), why.to_string()),
 		Ok(file) => file,
 	};
 	file.write_all(serialization.as_bytes())

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -252,11 +252,9 @@ pub enum Error {
 }
 
 impl error::Error for Error {
-	fn description(&self) -> &str {
-		match *self {
-			_ => "some kind of keychain error",
-		}
-	}
+	// placeholder for better error messaging
+	// TODO: investigate using source() fn in std::error
+	// to better propogate errors through
 }
 
 impl fmt::Display for Error {

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -37,7 +37,6 @@ use util::secp::pedersen::{Commitment, RangeProof};
 use util::secp::Signature;
 use util::secp::{ContextFlag, Secp256k1};
 
-
 pub use std::result::Result::{self, Err, Ok};
 
 /// Possible errors deriving from serializing or deserializing.
@@ -103,24 +102,12 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
+	// TODO: 'cause' has also been deprecated in favor of 'source()'
+	// leaving this here because we do not use it
 	fn cause(&self) -> Option<&dyn error::Error> {
 		match *self {
 			Error::IOErr(ref _e, ref _k) => Some(self),
 			_ => None,
-		}
-	}
-
-	fn description(&self) -> &str {
-		match *self {
-			Error::IOErr(ref e, _) => e,
-			Error::UnexpectedData { .. } => "unexpected data",
-			Error::CorruptedData => "corrupted data",
-			Error::CountError => "count error",
-			Error::SortError => "sort order",
-			Error::DuplicateError => "duplicate error",
-			Error::TooLargeReadErr => "too large read",
-			Error::HexError(_) => "hex error",
-			Error::InvalidBlockVersion => "invalid block version(YOU NEED UPDATE YOUR NODE)",
 		}
 	}
 }
@@ -868,7 +855,6 @@ pub trait PMMRable: Writeable + Clone + Debug + DefaultHashable {
 	fn elmt_size() -> Option<u16>;
 }
 
-
 /// Generic trait to ensure PMMR elements can be hashed with an index
 pub trait PMMRIndexHashable {
 	/// Hash with a given index
@@ -967,7 +953,6 @@ impl AsFixedBytes for keychain::Identifier {
 		IDENTIFIER_SIZE
 	}
 }
-
 
 //std::fmt::Result
 
@@ -1096,10 +1081,7 @@ where
 	struct FieldVisitor;
 	impl<'de> serde::de::Visitor<'de> for FieldVisitor {
 		type Value = Field;
-		fn expecting(
-			&self,
-			formatter: &mut std::fmt::Formatter,
-		) -> std::fmt::Result {
+		fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
 			std::fmt::Formatter::write_str(formatter, "variant identifier")
 		}
 		fn visit_u64<E>(self, value: u64) -> std::result::Result<Self::Value, E>
@@ -1202,10 +1184,7 @@ where
 	}
 	impl<'de> serde::de::Visitor<'de> for Visitor<'de> {
 		type Value = io::ErrorKind;
-		fn expecting(
-			&self,
-			formatter: &mut std::fmt::Formatter,
-		) -> std::fmt::Result {
+		fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
 			std::fmt::Formatter::write_str(formatter, "enum io::ErrorKind")
 		}
 		fn visit_enum<A>(self, data: A) -> std::result::Result<Self::Value, A::Error>

--- a/keychain/src/base58.rs
+++ b/keychain/src/base58.rs
@@ -90,18 +90,11 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
+	//TODO: replace cause with 'source()' and actually use it
+	// base58/keychain errors presently give hardly any info
+	// if encountered in upper levels
 	fn cause(&self) -> Option<&dyn error::Error> {
 		None
-	}
-	fn description(&self) -> &'static str {
-		match *self {
-			Error::BadByte(_) => "invalid b58 character",
-			Error::BadChecksum(_, _) => "invalid b58ck checksum",
-			Error::InvalidLength(_) => "invalid length for b58 type",
-			Error::InvalidVersion(_) => "invalid version for b58 type",
-			Error::TooShort(_) => "b58ck data less than 4 bytes",
-			Error::Other(_) => "unknown b58 error",
-		}
 	}
 }
 

--- a/keychain/src/extkey_bip32.rs
+++ b/keychain/src/extkey_bip32.rs
@@ -331,16 +331,6 @@ impl error::Error for Error {
 			None
 		}
 	}
-
-	fn description(&self) -> &str {
-		match *self {
-			Error::CannotDeriveFromHardenedKey => "cannot derive hardened key from public key",
-			Error::Ecdsa(ref e) => error::Error::description(e),
-			Error::InvalidChildNumber(_) => "child number is invalid",
-			Error::RngError(_) => "rng error",
-			Error::MnemonicError(_) => "mnemonic error",
-		}
-	}
 }
 
 impl From<secp::Error> for Error {

--- a/keychain/src/types.rs
+++ b/keychain/src/types.rs
@@ -62,11 +62,7 @@ impl From<extkey_bip32::Error> for Error {
 }
 
 impl error::Error for Error {
-	fn description(&self) -> &str {
-		match *self {
-			_ => "some kind of keychain error",
-		}
-	}
+	// placeholder for std::error members such as 'source()'
 }
 
 impl fmt::Display for Error {


### PR DESCRIPTION
This PR removes all usage of `std::error::Error::description()`.

It has been deprecated since Rust 1.42.  Instead, we need to implement `Display` for all relevant errors OR use `to_string()`

None of these were very helpful, to begin with.  It is impossible to move variable data up to higher levels in code with `description()` anyway, as it requires a string literal in return.  

There is now better tooling in functions such as `source()`, which does allow us to pass errors from lower levels to higher ones.

Mostly removal of old/unused code. Brings us into compatibility with future versions of rust, as far as `std::error::Error` trait is concerned. 

**Silences the following warnings:**

```bash
warning: use of deprecated associated function `std::error::Error::description`: use the Display impl or to_string()
   --> keychain/src/extkey_bip32.rs:338:41
    |
338 |             Error::Ecdsa(ref e) => error::Error::description(e),
    |                                                  ^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default
```

```bash
warning: use of deprecated associated function `std::error::Error::description`: use the Display impl or to_string()
  --> core/src/core/foundation.rs:52:68
   |
52 |         Err(why) => panic!("Couldn't create {}: {}", path.display(), why.description()),
   |                                                                          ^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
```