### PR TITLE
Fix bug where header fastsync ends up in endless loop

### DIFF
--- a/servers/src/epic/sync/header_sync.rs
+++ b/servers/src/epic/sync/header_sync.rs
@@ -95,7 +95,12 @@ impl HeaderSync {
 		} else {
 			peer_blocks = self.header_sync_due();
 		}
-		Ok((self.peer.info.get_headers().clone(), peer_blocks))
+
+		//remove headers that are lower than our current height.
+		let mut clean_headers: Vec<_> = self.peer.info.get_headers().clone();
+		clean_headers.retain(|x| x.height > self.header_head_height);
+
+		Ok((clean_headers, peer_blocks))
 	}
 
 	fn header_sync_due(&mut self) -> bool {


### PR DESCRIPTION
Fix a bug where peers are returning lower headers than current own height. This almost happens if less than the 512 headers need to be returned by peer.


## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (miscellaneous changes e.g. modifying .gitignore)
- [ ] Build (Affect build components like build tool, ci pipeline, dependencies, project version)
- [ ] Docs (documentation update)