### PR TITLE
Tolerate reorganizations in HeaderFastSync, fix infinite loop

### DIFF
--- a/servers/src/epic/sync/syncer.rs
+++ b/servers/src/epic/sync/syncer.rs
@@ -330,12 +330,10 @@ impl SyncRunner {
 				if let Ok(mut fastsync_headers) = fastsync_header_queue.try_lock() {
 					info!("------------ Downloaded headers in queue ------------");
 
-					let mut sorted: Vec<_> = fastsync_headers
-						.clone()
-						.into_iter()
-						.collect::<Vec<_>>()
-						.clone();
+					let mut sorted: Vec<_> =
+						fastsync_headers.clone().into_iter().collect::<Vec<_>>();
 					sorted.sort_by_key(|a| a.0);
+
 					for (key, value) in sorted.iter() {
 						info!(
 							"Start height: {:?}, Headers: {:?}, offset: {:?}",
@@ -358,12 +356,8 @@ impl SyncRunner {
 					}
 
 					let lowest_height = sorted.iter().next().clone().unwrap().0;
-					let current_height = chainsync.adapter.total_header_height().unwrap();
-					//warn!("current_height({}), lowest_height in fastsync_headers({})", current_height, lowest_height);
-
 					let fastsync_header = sorted.get(0);
 					let headers = &fastsync_header.unwrap().1.headers;
-					//warn!("first header height ({}), hash({:?})", headers[0].height, headers[0].hash());
 					let peer_info = &fastsync_header.unwrap().1.peer_info;
 
 					match chainsync


### PR DESCRIPTION
- In cases where we have a reorganization, peers will send us the lowest header that matches our records in `fastsync_headers`
- Because we were previously checking for entry at key = `current_height + 1`, case where alternative headers are sent was not handled (necessarily less than our own blockchain height)
- `if let Some(fastsync_header)` was returning None, and none of the following logic was executing
- Now, we take lowest entry from our `sorted` vector and use that height to fetch entry from queue
- Reorganization case is now handled properly, and recursive loop case is fixed.