### PR TITLE
Resolve "noop_method_call" warnings for rust 1.73+

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -239,14 +239,7 @@ impl GlobalConfig {
 			}
 			Err(e) => {
 				return Err(ConfigError::ParseError(
-					String::from(
-						self.config_file_path
-							.as_mut()
-							.unwrap()
-							.to_str()
-							.unwrap()
-							.clone(),
-					),
+					String::from(self.config_file_path.as_mut().unwrap().to_str().unwrap()),
 					String::from(format!("{}", e)),
 				));
 			}

--- a/servers/src/epic/server.rs
+++ b/servers/src/epic/server.rs
@@ -185,7 +185,7 @@ impl Server {
 	// This uses fs2 and should be safe cross-platform unless somebody abuses the file itself.
 	fn one_epic_at_a_time(config: &ServerConfig) -> Result<Arc<File>, Error> {
 		let path = Path::new(&config.db_root);
-		fs::create_dir_all(path.clone())?;
+		fs::create_dir_all(path)?;
 		let path = path.join("epic.lock");
 		let lock_file = fs::OpenOptions::new()
 			.read(true)

--- a/src/bin/epic.rs
+++ b/src/bin/epic.rs
@@ -100,7 +100,7 @@ fn real_main() -> i32 {
 				panic!("The generate value must be a positive integer: {}", e);
 			});
 
-		let url = taxes_args.value_of("from_wallet").unwrap().clone();
+		let url = taxes_args.value_of("from_wallet").unwrap();
 		let mut wallet_url = String::new();
 		if !url.contains("http") {
 			wallet_url.push_str("http://");


### PR DESCRIPTION
- Rust compiler added warnings to noop method calls (redundant calls that do nothing)
- These changes take rust compiler recommendations and accomodate them to silence warnings

Compiler output prior to these changes is as follows:

```bash
warning: call to `.clone()` on a reference in this situation does nothing
   --> servers/src/epic/server.rs:188:26
    |
188 |         fs::create_dir_all(path.clone())?;
    |                                ^^^^^^^^ help: remove this redundant call
    |
    = note: the type `Path` does not implement `Clone`, so calling `clone` on `&Path` copies the reference, which does not do anything and can be removed
    = note: `#[warn(noop_method_call)]` on by default

warning: call to `.clone()` on a reference in this situation does nothing
   --> config/src/config.rs:247:17
    |
247 |   ...                   .unwrap()
    |  ________________________________^
248 | | ...                   .clone(),
    | |______________________________^ help: remove this redundant call
    |
    = note: the type `str` does not implement `Clone`, so calling `clone` on `&str` copies the reference, which does not do anything and can be removed
    = note: `#[warn(noop_method_call)]` on by default

warning: call to `.clone()` on a reference in this situation does nothing
   --> src/bin/epic.rs:103:56
    |
103 |         let url = taxes_args.value_of("from_wallet").unwrap().clone();
    |                                                              ^^^^^^^^ help: remove this redundant call
    |
    = note: the type `str` does not implement `Clone`, so calling `clone` on `&str` copies the reference, which does not do anything and can be removed
    = note: `#[warn(noop_method_call)]` on by default
```

These warnings are now resolved.