### PR TITLE
Version bump (3.5.0), update checkpoints to height 2.2M

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "epic"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "blake2-rfc",
  "built",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "epic_api"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "bigint",
  "bytes 0.5.6",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "epic_chain"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "bigint",
  "bit-vec",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "epic_config"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "dirs",
  "epic_core",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "epic_core"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "bigint",
  "blake2-rfc",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "epic_keychain"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "blake2-rfc",
  "byteorder 1.5.0",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "epic_p2p"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "bitflags 1.3.2",
  "bytes 0.4.12",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "epic_pool"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "epic_servers"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "bigint",
  "chrono",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "epic_store"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "byteorder 1.5.0",
  "chrono",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "epic_util"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "backtrace",
  "base64 0.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "epic"
-version = "3.4.0"
+version = "3.5.0"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -50,14 +50,14 @@ reqwest = "0.11.11"
 
 tokio = { version = "1.32", features = ["full"] }
 
-epic_api = { path = "./api", version = "3.4.0" }
-epic_config = { path = "./config", version = "3.4.0" }
-epic_core = { path = "./core", version = "3.4.0" }
-epic_keychain = { path = "./keychain", version = "3.4.0" }
-epic_p2p = { path = "./p2p", version = "3.4.0" }
-epic_servers = { path = "./servers", version = "3.4.0" }
-epic_util = { path = "./util", version = "3.4.0" }
-epic_chain = { path = "./chain", version = "3.4.0" }
+epic_api = { path = "./api", version = "3.5.0" }
+epic_config = { path = "./config", version = "3.5.0" }
+epic_core = { path = "./core", version = "3.5.0" }
+epic_keychain = { path = "./keychain", version = "3.5.0" }
+epic_p2p = { path = "./p2p", version = "3.5.0" }
+epic_servers = { path = "./servers", version = "3.5.0" }
+epic_util = { path = "./util", version = "3.5.0" }
+epic_chain = { path = "./chain", version = "3.5.0" }
 
 cursive = { version = "0.16", default-features = false, features = [
     "pancurses-backend",
@@ -75,5 +75,5 @@ harness = false
 built = "0.3"
 
 [dev-dependencies]
-epic_store = { path = "./store", version = "3.4.0" }
+epic_store = { path = "./store", version = "3.5.0" }
 cucumber_rust = { version = "^0.5.1", default-features = false }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "epic_api"
-version = "3.4.0"
+version = "3.5.0"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "APIs for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -42,9 +42,9 @@ bytes = "0.5"
 
 
 
-epic_core = { path = "../core", version = "3.4.0" }
-epic_chain = { path = "../chain", version = "3.4.0" }
-epic_p2p = { path = "../p2p", version = "3.4.0" }
-epic_pool = { path = "../pool", version = "3.4.0" }
-epic_store = { path = "../store", version = "3.4.0" }
-epic_util = { path = "../util", version = "3.4.0" }
+epic_core = { path = "../core", version = "3.5.0" }
+epic_chain = { path = "../chain", version = "3.5.0" }
+epic_p2p = { path = "../p2p", version = "3.5.0" }
+epic_pool = { path = "../pool", version = "3.5.0" }
+epic_store = { path = "../store", version = "3.5.0" }
+epic_util = { path = "../util", version = "3.5.0" }

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "epic_chain"
-version = "3.4.0"
+version = "3.5.0"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Chain implementation for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -27,10 +27,10 @@ lazy_static = "1"
 regex = "1"
 bigint = "4.4.1"
 
-epic_core = { path = "../core", version = "3.4.0" }
-epic_keychain = { path = "../keychain", version = "3.4.0" }
-epic_store = { path = "../store", version = "3.4.0" }
-epic_util = { path = "../util", version = "3.4.0" }
+epic_core = { path = "../core", version = "3.5.0" }
+epic_keychain = { path = "../keychain", version = "3.5.0" }
+epic_store = { path = "../store", version = "3.5.0" }
+epic_util = { path = "../util", version = "3.5.0" }
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -505,9 +505,9 @@ impl BlockchainCheckpoints {
 				.unwrap(),
 			},
 			Checkpoint {
-				height: 2050000,
+				height: 2200000,
 				block_hash: Hash::from_hex(
-					"1a51bb18562e120f33783e53a70c449fd14197ac77082dc23d664c7f47a744c9",
+					"1243520890d08026daba8207ed3d67186da64d2b71b5c1e2dd26d34092dee6ba",
 				)
 				.unwrap(),
 			},

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "epic_config"
-version = "3.4.0"
+version = "3.5.0"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Configuration for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -16,10 +16,10 @@ serde_derive = "1"
 toml = "0.4"
 dirs = "1.0.3"
 
-epic_core = { path = "../core", version = "3.4.0" }
-epic_servers = { path = "../servers", version = "3.4.0" }
-epic_p2p = { path = "../p2p", version = "3.4.0" }
-epic_util = { path = "../util", version = "3.4.0" }
+epic_core = { path = "../core", version = "3.5.0" }
+epic_servers = { path = "../servers", version = "3.5.0" }
+epic_p2p = { path = "../p2p", version = "3.5.0" }
+epic_util = { path = "../util", version = "3.5.0" }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "epic_core"
-version = "3.4.0"
+version = "3.5.0"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Chain implementation for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -36,8 +36,8 @@ keccak-hash = "0.2.0"
 sha2 = "0.8.0"
 zeroize = "1.3.0"
 
-keychain = { package = "epic_keychain", path = "../keychain", version = "3.4.0" }
-util = { package = "epic_util", path = "../util", version = "3.4.0" }
+keychain = { package = "epic_keychain", path = "../keychain", version = "3.5.0" }
+util = { package = "epic_util", path = "../util", version = "3.5.0" }
 randomx = { git = "https://github.com/EpicCash/randomx-rust.git", tag = "v0.1.1" }
 progpow = { git = "https://github.com/EpicCash/progpow-rust.git", tag = "v0.1.0" }
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+epic (3.5.0) focal; urgency=high
+
+  [ Epic Team ]
+  * Numerous dependency updates and refactoring
+  * Greatly reduced blockchain sync time
+  * Options to customize how much PoW to verify while syncing
+  * Reduce CPU usage for node server
+  * Fixes compiler warnings
+  * Improved stratum async code
+  * Greatly improved handling of OrphanBlockPool
+  * Addition of blockchain checkpoints for fastsync mode
+  * Tolerate reorgs in HeaderSync, fix endless loop
+
+ -- Epic Team <admin@epic.tech>  Wed, 21 Nov 2023 12:00:00 +0000
+
 epic (3.4.0) focal; urgency=high
 
   [ Epic Team ]

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "epic_keychain"
-version = "3.4.0"
+version = "3.5.0"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Chain implementation for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -27,4 +27,4 @@ ripemd160 = "0.9"
 sha2 = "0.9"
 pbkdf2 = "0.8"
 
-epic_util = { path = "../util", version = "3.4.0" }
+epic_util = { path = "../util", version = "3.5.0" }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "epic_p2p"
-version = "3.4.0"
+version = "3.5.0"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Chain implementation for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -23,10 +23,10 @@ tempfile = "3.0.5"
 log = "0.4"
 chrono = { version = "0.4.31", features = ["serde"] }
 
-epic_core = { path = "../core", version = "3.4.0" }
-epic_store = { path = "../store", version = "3.4.0" }
-epic_util = { path = "../util", version = "3.4.0" }
-epic_chain = { path = "../chain", version = "3.4.0" }
+epic_core = { path = "../core", version = "3.5.0" }
+epic_store = { path = "../store", version = "3.5.0" }
+epic_util = { path = "../util", version = "3.5.0" }
+epic_chain = { path = "../chain", version = "3.5.0" }
 
 [dev-dependencies]
-epic_pool = { path = "../pool", version = "3.4.0" }
+epic_pool = { path = "../pool", version = "3.5.0" }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "epic_pool"
-version = "3.4.0"
+version = "3.5.0"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Chain implementation for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -19,10 +19,10 @@ chrono = "0.4.31"
 failure = "0.1"
 failure_derive = "0.1"
 
-epic_core = { path = "../core", version = "3.4.0" }
-epic_keychain = { path = "../keychain", version = "3.4.0" }
-epic_store = { path = "../store", version = "3.4.0" }
-epic_util = { path = "../util", version = "3.4.0" }
+epic_core = { path = "../core", version = "3.5.0" }
+epic_keychain = { path = "../keychain", version = "3.5.0" }
+epic_store = { path = "../store", version = "3.5.0" }
+epic_util = { path = "../util", version = "3.5.0" }
 
 [dev-dependencies]
-epic_chain = { path = "../chain", version = "3.4.0" }
+epic_chain = { path = "../chain", version = "3.5.0" }

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "epic_servers"
-version = "3.4.0"
+version = "3.5.0"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -37,11 +37,11 @@ trust-dns-resolver = "0.11.1"
 walkdir = "2.2.9"
 
 
-epic_api = { path = "../api", version = "3.4.0" }
-epic_chain = { path = "../chain", version = "3.4.0" }
-epic_core = { path = "../core", version = "3.4.0" }
-epic_keychain = { path = "../keychain", version = "3.4.0" }
-epic_p2p = { path = "../p2p", version = "3.4.0" }
-epic_pool = { path = "../pool", version = "3.4.0" }
-epic_store = { path = "../store", version = "3.4.0" }
-epic_util = { path = "../util", version = "3.4.0" }
+epic_api = { path = "../api", version = "3.5.0" }
+epic_chain = { path = "../chain", version = "3.5.0" }
+epic_core = { path = "../core", version = "3.5.0" }
+epic_keychain = { path = "../keychain", version = "3.5.0" }
+epic_p2p = { path = "../p2p", version = "3.5.0" }
+epic_pool = { path = "../pool", version = "3.5.0" }
+epic_store = { path = "../store", version = "3.5.0" }
+epic_util = { path = "../util", version = "3.5.0" }

--- a/src/bin/epic.yml
+++ b/src/bin/epic.yml
@@ -1,5 +1,5 @@
 name: epic
-version: "3.4.0"
+version: "3.5.0"
 about: Lightweight implementation of the MimbleWimble protocol.
 author: The Epic Team
 

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "epic_store"
-version = "3.4.0"
+version = "3.5.0"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -25,8 +25,8 @@ serde = "1"
 serde_derive = "1"
 log = "0.4"
 
-epic_core = { path = "../core", version = "3.4.0" }
-epic_util = { path = "../util", version = "3.4.0" }
+epic_core = { path = "../core", version = "3.5.0" }
+epic_util = { path = "../util", version = "3.5.0" }
 
 [dev-dependencies]
 chrono = "0.4.31"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "epic_util"
-version = "3.4.0"
+version = "3.5.0"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"


### PR DESCRIPTION
- Updates blockchain checkpoints, so that `skip_pow_validation = true` will start verifying PoW at height 2,200,000.  Current blockchain height is about 36,000 blocks higher than this (https://github.com/EpicCash/epic/commit/3138beb1e126bc8dfa74aabee0c04e56110f9ce1)
- Update version for 3.5.0 in all applicable files, and Cargo.lock (https://github.com/EpicCash/epic/commit/ef84d4f4c27531df75a9be2683e354f6ccacbe80)
