### PR TITLE
Minimum peer agent version

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -277,6 +277,11 @@ seeds = [\"95.217.197.180:3517\",\"5.161.127.56:3414\",\"5.75.242.4:3414\",\"5.7
 # A preferred dandelion_peer, mainly used for testing dandelion
 # dandelion_peer = \"10.0.0.1:13144\"
 
+
+# minimum version for other peers that can connect
+peer_min_major = 3
+peer_min_minor = 4
+
 "
 		.to_string(),
 	);

--- a/edna.toml
+++ b/edna.toml
@@ -109,6 +109,9 @@ seeding_type = "DNSSeed"
 # A preferred dandelion_peer, mainly used for testing dandelion
 # dandelion_peer = "10.0.0.1:13144"
 
+peer_min_major = 3
+peer_min_minor = 4
+
 [server.p2p_config.capabilities]
 bits = 31
 
@@ -213,4 +216,3 @@ log_max_size = 16777216
 
 #maximum count of the log files to rotate over
 log_max_files = 32
-

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -324,7 +324,7 @@ impl P2PConfig {
 	/// return peer min major version
 	pub fn peer_min_major(&self) -> u32 {
 		match self.peer_min_major {
-			Some(n) => std::cmp::min(PEER_MIN_MAJOR, n),
+			Some(n) => std::cmp::max(PEER_MIN_MAJOR, n),
 			None => PEER_MIN_MAJOR,
 		}
 	}

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -60,6 +60,12 @@ const PEER_MIN_PREFERRED_OUTBOUND_COUNT: u32 = 8;
 /// than allowed by PEER_MAX_INBOUND_COUNT to encourage network bootstrapping.
 const PEER_LISTENER_BUFFER_COUNT: u32 = 8;
 
+/// The minimum Major version a peer must have
+pub const PEER_MIN_MAJOR: u32 = 3;
+
+/// The minimum Minor version a peer must have
+pub const PEER_MIN_MINOR: u32 = 4;
+
 #[derive(Debug)]
 pub enum Error {
 	Serialization(ser::Error),
@@ -241,6 +247,10 @@ pub struct P2PConfig {
 	pub peer_listener_buffer_count: Option<u32>,
 
 	pub dandelion_peer: Option<PeerAddr>,
+
+	pub peer_min_major: Option<u32>,
+
+	pub peer_min_minor: Option<u32>,
 }
 
 /// Default address for peer-to-peer connections.
@@ -262,6 +272,8 @@ impl Default for P2PConfig {
 			peer_min_preferred_outbound_count: None,
 			peer_listener_buffer_count: None,
 			dandelion_peer: None,
+			peer_min_major: None,
+			peer_min_minor: None,
 		}
 	}
 }
@@ -306,6 +318,22 @@ impl P2PConfig {
 		match self.peer_listener_buffer_count {
 			Some(n) => n,
 			None => PEER_LISTENER_BUFFER_COUNT,
+		}
+	}
+
+	/// return peer min major version
+	pub fn peer_min_major(&self) -> u32 {
+		match self.peer_min_major {
+			Some(n) => std::cmp::min(PEER_MIN_MAJOR, n),
+			None => PEER_MIN_MAJOR,
+		}
+	}
+
+	/// return peer min minor version
+	pub fn peer_min_minor(&self) -> u32 {
+		match self.peer_min_minor {
+			Some(n) => std::cmp::max(PEER_MIN_MINOR, n),
+			None => PEER_MIN_MINOR,
 		}
 	}
 }


### PR DESCRIPTION
To make it easier for nodes to connect only to compatible nodes, i introduce a minimum Epic agent Version.
If the Minor and Major version does not met the minium minor and major version, then the node is not connecting. 
The version can be set in epic-server.tom with 2 new options:

peer_min_major = 3
peer_min_minor = 4

This should replace the Version Monitor checker in future.
