### PR TITLE
Update croaring dependency to 1.0.1, croaring-sys 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,21 +503,21 @@ dependencies = [
 
 [[package]]
 name = "croaring"
-version = "0.3.10"
-source = "git+https://github.com/EricShimizuKarbstein/croaring-rs.git?branch=not-native-march#59e23d8d8b0cef377d6dc506a1b872b09eebba47"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7266f0a7275b00ce4c4f4753e8c31afdefe93828101ece83a06e2ddab1dd1010"
 dependencies = [
+ "byteorder 1.5.0",
  "croaring-sys",
- "libc",
 ]
 
 [[package]]
 name = "croaring-sys"
-version = "0.3.10"
-source = "git+https://github.com/EricShimizuKarbstein/croaring-rs.git?branch=not-native-march#59e23d8d8b0cef377d6dc506a1b872b09eebba47"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47112498c394a7067949ebc07ef429b7384a413cf0efcf675846a47bcd307fb"
 dependencies = [
- "bindgen",
  "cc",
- "libc",
 ]
 
 [[package]]

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -15,9 +15,7 @@ bitflags = "1"
 byteorder = "1"
 failure = "0.1"
 failure_derive = "0.1"
-# FIRME: In the long run we should fix the conflicts and use a recent version of croaring
-# croaring = "0.4.5"
-croaring = { git = "https://github.com/EricShimizuKarbstein/croaring-rs.git", branch = "not-native-march", version = "0.3.10" }
+croaring = "1.0.1"
 log = "0.4"
 serde = "1"
 serde_derive = "1"

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -22,7 +22,7 @@ use crate::core::pow::{Difficulty, PoWType};
 use crate::core::ser::ProtocolVersion;
 use crate::types::{CommitPos, Tip};
 use crate::util::secp::pedersen::Commitment;
-use croaring::Bitmap;
+use croaring::{Bitmap, Portable};
 use epic_store as store;
 use epic_store::{option_to_not_found, to_key, Error, SerIterator};
 use std::convert::TryInto;
@@ -402,7 +402,7 @@ impl<'a> Batch<'a> {
 			.db
 			.get(&to_key(BLOCK_INPUT_BITMAP_PREFIX, &mut bh.to_vec()))
 		{
-			Ok(Bitmap::deserialize(&bytes))
+			Ok(Bitmap::deserialize::<Portable>(&bytes))
 		} else {
 			Err(Error::NotFoundErr("legacy block input bitmap".to_string()).into())
 		}

--- a/chain/src/txhashset/bitmap_accumulator.rs
+++ b/chain/src/txhashset/bitmap_accumulator.rs
@@ -148,7 +148,7 @@ impl BitmapAccumulator {
 		let mut pmmr = PMMR::at(&mut self.backend, last_pos);
 		let chunk_pos = pmmr::insertion_to_pmmr_index(chunk_idx + 1);
 		let rewind_pos = chunk_pos.saturating_sub(1);
-		pmmr.rewind(rewind_pos, &Bitmap::create())
+		pmmr.rewind(rewind_pos, &Bitmap::new())
 			.map_err(|e| ErrorKind::Other(e))?;
 		Ok(())
 	}

--- a/chain/src/txhashset/txhashset.rs
+++ b/chain/src/txhashset/txhashset.rs
@@ -774,7 +774,7 @@ impl<'a> HeaderExtension<'a> {
 
 		let header_pos = pmmr::insertion_to_pmmr_index(header.height + 1);
 		self.pmmr
-			.rewind(header_pos, &Bitmap::create())
+			.rewind(header_pos, &Bitmap::new())
 			.map_err(&ErrorKind::TxHashSetErr)?;
 
 		// Update our head to reflect the header we rewound to.
@@ -1193,7 +1193,7 @@ impl<'a> Extension<'a> {
 			.rewind(output_pos, &bitmap)
 			.map_err(&ErrorKind::TxHashSetErr)?;
 		self.kernel_pmmr
-			.rewind(kernel_pos, &Bitmap::create())
+			.rewind(kernel_pos, &Bitmap::new())
 			.map_err(&ErrorKind::TxHashSetErr)?;
 		Ok(())
 	}
@@ -1627,7 +1627,7 @@ fn input_pos_to_rewind(
 	head_header: &BlockHeader,
 	batch: &Batch<'_>,
 ) -> Result<Bitmap, Error> {
-	let mut bitmap = Bitmap::create();
+	let mut bitmap = Bitmap::new();
 	let mut current = head_header.clone();
 	while current.height > block_header.height {
 		if let Ok(block_bitmap) = batch.get_block_input_bitmap(&current.hash()) {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,9 +12,7 @@ edition = "2018"
 [dependencies]
 blake2 = { package = "blake2-rfc", version = "0.2" }
 byteorder = "1"
-# FIRME: In the long run we should fix the conflicts and use a recent version of croaring
-# croaring = "0.4.5"
-croaring = { git = "https://github.com/EricShimizuKarbstein/croaring-rs.git", branch = "not-native-march", version = "0.3.10" }
+croaring = "1.0.1"
 enum_primitive = "0.1"
 failure = "0.1"
 failure_derive = "0.1"

--- a/core/src/pow/cuckatoo.rs
+++ b/core/src/pow/cuckatoo.rs
@@ -61,7 +61,7 @@ where
 			proof_size,
 			links: vec![],
 			adj_list: vec![],
-			visited: Bitmap::create(),
+			visited: Bitmap::new(),
 			solutions: vec![],
 			nil: T::max_value(),
 		})
@@ -72,7 +72,7 @@ where
 		self.links = Vec::with_capacity(2 * self.max_nodes as usize);
 		self.adj_list = vec![T::max_value(); 2 * self.max_nodes as usize];
 		self.solutions = vec![Proof::zero(self.proof_size); 1];
-		self.visited = Bitmap::create();
+		self.visited = Bitmap::new();
 		Ok(())
 	}
 

--- a/core/src/pow/lean.rs
+++ b/core/src/pow/lean.rs
@@ -36,8 +36,8 @@ impl Lean {
 		let params = CuckooParams::new(edge_bits, 42).unwrap();
 
 		// edge bitmap, before trimming all of them are on
-		let mut edges = Bitmap::create_with_capacity(params.num_edges as u32);
-		edges.flip_inplace(0..params.num_edges);
+		let mut edges = Bitmap::with_container_capacity(params.num_edges as u32);
+		edges.flip_inplace(0..params.num_edges as u32);
 
 		Lean { params, edges }
 	}
@@ -67,7 +67,7 @@ impl Lean {
 	fn count_and_kill(&mut self) {
 		// on each side u or v of the bipartite graph
 		for uorv in 0..2 {
-			let mut nodes = Bitmap::create();
+			let mut nodes = Bitmap::new();
 			// increment count for each node
 			for e in self.edges.iter() {
 				let node = self.params.sipnode(e, uorv, false).unwrap();
@@ -75,7 +75,7 @@ impl Lean {
 			}
 
 			// then kill edges with lone nodes (no neighbour at ^1)
-			let mut to_kill = Bitmap::create();
+			let mut to_kill = Bitmap::new();
 			for e in self.edges.iter() {
 				let node = self.params.sipnode(e, uorv, false).unwrap();
 				if !nodes.contains(node ^ 1) {

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -11,9 +11,7 @@ edition = "2018"
 
 [dependencies]
 byteorder = "1"
-# FIRME: In the long run we should fix the conflicts and use a recent version of croaring
-# croaring = "0.4.5"
-croaring = { git = "https://github.com/EricShimizuKarbstein/croaring-rs.git", branch = "not-native-march", version = "0.3.10" }
+croaring = "1.0.1"
 env_logger = "0.5"
 libc = "0.2"
 failure = "0.1"

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -110,7 +110,7 @@ where
 	Ok(())
 }
 
-use croaring::Bitmap;
+use croaring::{Bitmap, Portable};
 use std::io::{self, Read};
 /// Read Bitmap from a file
 pub fn read_bitmap<P: AsRef<Path>>(file_path: P) -> io::Result<Bitmap> {
@@ -118,5 +118,5 @@ pub fn read_bitmap<P: AsRef<Path>>(file_path: P) -> io::Result<Bitmap> {
 	let f_md = bitmap_file.metadata()?;
 	let mut buffer = Vec::with_capacity(f_md.len() as usize);
 	bitmap_file.read_to_end(&mut buffer)?;
-	Ok(Bitmap::deserialize(&buffer))
+	Ok(Bitmap::deserialize::<Portable>(&buffer))
 }

--- a/store/src/pmmr.rs
+++ b/store/src/pmmr.rs
@@ -411,7 +411,7 @@ impl<T: PMMRable> PMMRBackend<T> {
 	}
 
 	fn pos_to_rm(&self, cutoff_pos: u64, rewind_rm_pos: &Bitmap) -> (Bitmap, Bitmap) {
-		let mut expanded = Bitmap::create();
+		let mut expanded = Bitmap::new();
 
 		let leaf_pos_to_rm =
 			self.leaf_set

--- a/store/src/types.rs
+++ b/store/src/types.rs
@@ -16,8 +16,7 @@ use memmap;
 use tempfile::tempfile;
 
 use crate::core::ser::{
-	self, BinWriter, ProtocolVersion, Readable, Reader, StreamingReader, Writeable,
-	Writer,
+	self, BinWriter, ProtocolVersion, Readable, Reader, StreamingReader, Writeable, Writer,
 };
 use std::fmt::Debug;
 use std::fs::{self, File, OpenOptions};


### PR DESCRIPTION
Updates `croaring` crate to 1.0.1, `croaring-sys` to 1.1.0

Also removes dependency on a git repository and rust build scripts. Package is now fetched from `crates.io`.

There were a few semantic changes to the way `Bitmap`s are handled, and its member functions.  These have been accommodated and tests are passing functionally.