### PR TITLE
Bump version to 3.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.1"
+version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c764d619ca78fccbf3069b37bd7af92577f044bb15236036662d79b6559f25b7"
+checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "byte-tools"
@@ -380,11 +380,10 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
 dependencies = [
- "jobserver",
  "libc",
 ]
 
@@ -421,7 +420,7 @@ dependencies = [
  "num-traits 0.2.18",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -931,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "epic"
-version = "3.5.0"
+version = "3.5.2"
 dependencies = [
  "blake2-rfc",
  "built",
@@ -973,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "epic_api"
-version = "3.5.0"
+version = "3.5.2"
 dependencies = [
  "bigint",
  "bytes 0.5.6",
@@ -1007,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "epic_chain"
-version = "3.5.0"
+version = "3.5.2"
 dependencies = [
  "bigint",
  "bit-vec",
@@ -1033,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "epic_config"
-version = "3.5.0"
+version = "3.5.2"
 dependencies = [
  "dirs",
  "epic_core",
@@ -1049,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "epic_core"
-version = "3.5.0"
+version = "3.5.2"
 dependencies = [
  "bigint",
  "blake2-rfc",
@@ -1082,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "epic_keychain"
-version = "3.5.0"
+version = "3.5.2"
 dependencies = [
  "blake2-rfc",
  "byteorder 1.5.0",
@@ -1104,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "epic_p2p"
-version = "3.5.0"
+version = "3.5.2"
 dependencies = [
  "bitflags 1.3.2",
  "bytes 0.4.12",
@@ -1127,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "epic_pool"
-version = "3.5.0"
+version = "3.5.2"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -1146,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "epic_servers"
-version = "3.5.0"
+version = "3.5.2"
 dependencies = [
  "bigint",
  "chrono",
@@ -1183,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "epic_store"
-version = "3.5.0"
+version = "3.5.2"
 dependencies = [
  "byteorder 1.5.0",
  "chrono",
@@ -1206,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "epic_util"
-version = "3.5.0"
+version = "3.5.2"
 dependencies = [
  "backtrace",
  "base64 0.9.3",
@@ -1922,15 +1921,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
-name = "jobserver"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2595,9 +2585,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.100"
+version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae94056a791d0e1217d18b6cbdccb02c61e3054fc69893607f4067e3bb0b1fd1"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",
@@ -4729,7 +4719,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -4747,7 +4737,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -4767,17 +4757,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.3",
+ "windows_aarch64_msvc 0.52.3",
+ "windows_i686_gnu 0.52.3",
+ "windows_i686_msvc 0.52.3",
+ "windows_x86_64_gnu 0.52.3",
+ "windows_x86_64_gnullvm 0.52.3",
+ "windows_x86_64_msvc 0.52.3",
 ]
 
 [[package]]
@@ -4788,9 +4778,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4800,9 +4790,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4812,9 +4802,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4824,9 +4814,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4836,9 +4826,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4848,9 +4838,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4860,9 +4850,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "epic"
 version = "3.5.2"
-authors = ["Epic Foundation <epiccash@brickabode.com>"]
+authors = ["Epic Foundation <info@epiccash.com>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "epic"
-version = "3.5.0"
+version = "3.5.2"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["crypto", "epic", "mimblewimble"]
 readme = "README.md"
 exclude = ["**/*.epic", "**/*.epic2"]
 build = "src/build/build.rs"
-edition = "2018"
+edition = "2021"
 
 [workspace]
 members = [
@@ -50,14 +50,14 @@ reqwest = "0.11.11"
 
 tokio = { version = "1.32", features = ["full"] }
 
-epic_api = { path = "./api", version = "3.5.0" }
-epic_config = { path = "./config", version = "3.5.0" }
-epic_core = { path = "./core", version = "3.5.0" }
-epic_keychain = { path = "./keychain", version = "3.5.0" }
-epic_p2p = { path = "./p2p", version = "3.5.0" }
-epic_servers = { path = "./servers", version = "3.5.0" }
-epic_util = { path = "./util", version = "3.5.0" }
-epic_chain = { path = "./chain", version = "3.5.0" }
+epic_api = { path = "./api", version = "3.5.2" }
+epic_config = { path = "./config", version = "3.5.2" }
+epic_core = { path = "./core", version = "3.5.2" }
+epic_keychain = { path = "./keychain", version = "3.5.2" }
+epic_p2p = { path = "./p2p", version = "3.5.2" }
+epic_servers = { path = "./servers", version = "3.5.2" }
+epic_util = { path = "./util", version = "3.5.2" }
+epic_chain = { path = "./chain", version = "3.5.2" }
 
 cursive = { version = "0.17", default-features = false, features = [
     "pancurses-backend",
@@ -75,5 +75,5 @@ harness = false
 built = { version = "0.7.1", features = ["git2", "cargo-lock"] }
 
 [dev-dependencies]
-epic_store = { path = "./store", version = "3.5.0" }
+epic_store = { path = "./store", version = "3.5.2" }
 cucumber_rust = { version = "^0.5.1", default-features = false }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "epic_api"
-version = "3.5.0"
+version = "3.5.2"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "APIs for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"
 keywords = ["crypto", "epic", "mimblewimble"]
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 easy-jsonrpc-mw = "0.5.4"
@@ -42,9 +42,9 @@ bytes = "0.5"
 
 
 
-epic_core = { path = "../core", version = "3.5.0" }
-epic_chain = { path = "../chain", version = "3.5.0" }
-epic_p2p = { path = "../p2p", version = "3.5.0" }
-epic_pool = { path = "../pool", version = "3.5.0" }
-epic_store = { path = "../store", version = "3.5.0" }
-epic_util = { path = "../util", version = "3.5.0" }
+epic_core = { path = "../core", version = "3.5.2" }
+epic_chain = { path = "../chain", version = "3.5.2" }
+epic_p2p = { path = "../p2p", version = "3.5.2" }
+epic_pool = { path = "../pool", version = "3.5.2" }
+epic_store = { path = "../store", version = "3.5.2" }
+epic_util = { path = "../util", version = "3.5.2" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "epic_api"
 version = "3.5.2"
-authors = ["Epic Foundation <epiccash@brickabode.com>"]
+authors = ["Epic Foundation <info@epiccash.com>"]
 description = "APIs for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "epic_chain"
-version = "3.5.0"
+version = "3.5.2"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Chain implementation for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"
 keywords = ["crypto", "epic", "mimblewimble"]
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bit-vec = "0.6"
@@ -25,10 +25,10 @@ lazy_static = "1"
 regex = "1"
 bigint = "4.4.1"
 
-epic_core = { path = "../core", version = "3.5.0" }
-epic_keychain = { path = "../keychain", version = "3.5.0" }
-epic_store = { path = "../store", version = "3.5.0" }
-epic_util = { path = "../util", version = "3.5.0" }
+epic_core = { path = "../core", version = "3.5.2" }
+epic_keychain = { path = "../keychain", version = "3.5.2" }
+epic_store = { path = "../store", version = "3.5.2" }
+epic_util = { path = "../util", version = "3.5.2" }
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "epic_chain"
 version = "3.5.2"
-authors = ["Epic Foundation <epiccash@brickabode.com>"]
+authors = ["Epic Foundation <info@epiccash.com>"]
 description = "Chain implementation for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "epic_config"
-version = "3.5.0"
+version = "3.5.2"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Configuration for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"
 keywords = ["crypto", "epic", "mimblewimble"]
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 rand = "0.6"
@@ -16,10 +16,10 @@ serde_derive = "1"
 toml = "0.4"
 dirs = "1.0.3"
 
-epic_core = { path = "../core", version = "3.5.0" }
-epic_servers = { path = "../servers", version = "3.5.0" }
-epic_p2p = { path = "../p2p", version = "3.5.0" }
-epic_util = { path = "../util", version = "3.5.0" }
+epic_core = { path = "../core", version = "3.5.2" }
+epic_servers = { path = "../servers", version = "3.5.2" }
+epic_p2p = { path = "../p2p", version = "3.5.2" }
+epic_util = { path = "../util", version = "3.5.2" }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "epic_config"
 version = "3.5.2"
-authors = ["Epic Foundation <epiccash@brickabode.com>"]
+authors = ["Epic Foundation <info@epiccash.com>"]
 description = "Configuration for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "epic_core"
-version = "3.5.0"
+version = "3.5.2"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Chain implementation for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"
 keywords = ["crypto", "epic", "mimblewimble"]
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 blake2 = { package = "blake2-rfc", version = "0.2" }
@@ -34,8 +34,8 @@ keccak-hash = "0.2.0"
 sha2 = "0.8.0"
 zeroize = "1.3.0"
 
-keychain = { package = "epic_keychain", path = "../keychain", version = "3.5.0" }
-util = { package = "epic_util", path = "../util", version = "3.5.0" }
+keychain = { package = "epic_keychain", path = "../keychain", version = "3.5.2" }
+util = { package = "epic_util", path = "../util", version = "3.5.2" }
 randomx = { git = "https://github.com/EpicCash/randomx-rust.git", tag = "v0.1.1" }
 progpow = { git = "https://github.com/EpicCash/progpow-rust.git", tag = "v0.1.0" }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "epic_core"
 version = "3.5.2"
-authors = ["Epic Foundation <epiccash@brickabode.com>"]
+authors = ["Epic Foundation <info@epiccash.com>"]
 description = "Chain implementation for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"

--- a/core/fuzz/Cargo.toml
+++ b/core/fuzz/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "epic_core-fuzz"
 version = "0.0.3"
-authors = ["Epic Foundation <epiccash@brickabode.com>"]
+authors = ["Epic Foundation <info@epiccash.com>"]
 publish = false
 
 [package.metadata]

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,7 +5,7 @@ epic (3.5.2) focal; urgency=medium
   * Update tableview dependency to 0.14.0
   * Resolve libgit2-sys dependabot vulnerability
 
- -- Epic Team <admin@epic.tech>  Wed, 22 Feb 2024 12:00:00 +0000
+ -- Epic Team <info@epiccash.com>  Wed, 22 Feb 2024 12:00:00 +0000
 
 epic (3.5.0) focal; urgency=high
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+epic (3.5.2) focal; urgency=medium
+
+  [ Epic Team ]
+  * Update cursive depdendency to 0.17
+  * Update tableview dependency to 0.14.0
+  * Resolve libgit2-sys dependabot vulnerability
+
+ -- Epic Team <admin@epic.tech>  Wed, 22 Feb 2024 12:00:00 +0000
+
 epic (3.5.0) focal; urgency=high
 
   [ Epic Team ]

--- a/debian/control
+++ b/debian/control
@@ -1,10 +1,10 @@
 Source: epic
 Section: utils
 Priority: optional
-Maintainer: Epic Team <admin@epic.tech>
+Maintainer: Epic Team <info@epiccash.com>
 Build-Depends: build-essential, debhelper, cmake, libclang-dev, libncurses5-dev, clang, libncursesw5-dev, cargo, rustc
 Standards-Version: 4.0.0
-Homepage: http://brickabode.com/
+Homepage: https://epiccash.com
 
 Package: epic
 Architecture: amd64

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "epic_keychain"
-version = "3.5.0"
+version = "3.5.2"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Chain implementation for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"
 keywords = ["crypto", "epic", "mimblewimble"]
 workspace = '..'
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 byteorder = "1"
@@ -27,4 +27,4 @@ ripemd160 = "0.9"
 sha2 = "0.9"
 pbkdf2 = "0.8"
 
-epic_util = { path = "../util", version = "3.5.0" }
+epic_util = { path = "../util", version = "3.5.2" }

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "epic_keychain"
 version = "3.5.2"
-authors = ["Epic Foundation <epiccash@brickabode.com>"]
+authors = ["Epic Foundation <info@epiccash.com>"]
 description = "Chain implementation for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "epic_p2p"
-version = "3.5.0"
+version = "3.5.2"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Chain implementation for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"
 keywords = ["crypto", "epic", "mimblewimble"]
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bitflags = "1"
@@ -23,10 +23,10 @@ tempfile = "3.0.5"
 log = "0.4"
 chrono = { version = "0.4.31", features = ["serde"] }
 
-epic_core = { path = "../core", version = "3.5.0" }
-epic_store = { path = "../store", version = "3.5.0" }
-epic_util = { path = "../util", version = "3.5.0" }
-epic_chain = { path = "../chain", version = "3.5.0" }
+epic_core = { path = "../core", version = "3.5.2" }
+epic_store = { path = "../store", version = "3.5.2" }
+epic_util = { path = "../util", version = "3.5.2" }
+epic_chain = { path = "../chain", version = "3.5.2" }
 
 [dev-dependencies]
-epic_pool = { path = "../pool", version = "3.5.0" }
+epic_pool = { path = "../pool", version = "3.5.2" }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "epic_p2p"
 version = "3.5.2"
-authors = ["Epic Foundation <epiccash@brickabode.com>"]
+authors = ["Epic Foundation <info@epiccash.com>"]
 description = "Chain implementation for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "epic_pool"
-version = "3.5.0"
+version = "3.5.2"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Chain implementation for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"
 keywords = ["crypto", "epic", "mimblewimble"]
 workspace = '..'
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 blake2-rfc = "0.2"
@@ -19,10 +19,10 @@ chrono = "0.4.31"
 failure = "0.1"
 failure_derive = "0.1"
 
-epic_core = { path = "../core", version = "3.5.0" }
-epic_keychain = { path = "../keychain", version = "3.5.0" }
-epic_store = { path = "../store", version = "3.5.0" }
-epic_util = { path = "../util", version = "3.5.0" }
+epic_core = { path = "../core", version = "3.5.2" }
+epic_keychain = { path = "../keychain", version = "3.5.2" }
+epic_store = { path = "../store", version = "3.5.2" }
+epic_util = { path = "../util", version = "3.5.2" }
 
 [dev-dependencies]
-epic_chain = { path = "../chain", version = "3.5.0" }
+epic_chain = { path = "../chain", version = "3.5.2" }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "epic_pool"
 version = "3.5.2"
-authors = ["Epic Foundation <epiccash@brickabode.com>"]
+authors = ["Epic Foundation <info@epiccash.com>"]
 description = "Chain implementation for epic, a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "epic_servers"
 version = "3.5.2"
-authors = ["Epic Foundation <epiccash@brickabode.com>"]
+authors = ["Epic Foundation <info@epiccash.com>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"

--- a/servers/Cargo.toml
+++ b/servers/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "epic_servers"
-version = "3.5.0"
+version = "3.5.2"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"
 keywords = ["crypto", "epic", "mimblewimble"]
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 hyper = { version = "0.14.27", features = ["full"]}
@@ -37,11 +37,11 @@ trust-dns-resolver = "0.11.1"
 walkdir = "2.2.9"
 
 
-epic_api = { path = "../api", version = "3.5.0" }
-epic_chain = { path = "../chain", version = "3.5.0" }
-epic_core = { path = "../core", version = "3.5.0" }
-epic_keychain = { path = "../keychain", version = "3.5.0" }
-epic_p2p = { path = "../p2p", version = "3.5.0" }
-epic_pool = { path = "../pool", version = "3.5.0" }
-epic_store = { path = "../store", version = "3.5.0" }
-epic_util = { path = "../util", version = "3.5.0" }
+epic_api = { path = "../api", version = "3.5.2" }
+epic_chain = { path = "../chain", version = "3.5.2" }
+epic_core = { path = "../core", version = "3.5.2" }
+epic_keychain = { path = "../keychain", version = "3.5.2" }
+epic_p2p = { path = "../p2p", version = "3.5.2" }
+epic_pool = { path = "../pool", version = "3.5.2" }
+epic_store = { path = "../store", version = "3.5.2" }
+epic_util = { path = "../util", version = "3.5.2" }

--- a/src/bin/epic.yml
+++ b/src/bin/epic.yml
@@ -1,5 +1,5 @@
 name: epic
-version: "3.5.0"
+version: "3.5.2"
 about: Lightweight implementation of the MimbleWimble protocol.
 author: The Epic Team
 

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "epic_store"
-version = "3.5.0"
+version = "3.5.2"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"
 keywords = ["crypto", "epic", "mimblewimble"]
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 byteorder = "1"
@@ -23,8 +23,8 @@ serde = "1"
 serde_derive = "1"
 log = "0.4"
 
-epic_core = { path = "../core", version = "3.5.0" }
-epic_util = { path = "../util", version = "3.5.0" }
+epic_core = { path = "../core", version = "3.5.2" }
+epic_util = { path = "../util", version = "3.5.2" }
 
 [dev-dependencies]
 chrono = "0.4.31"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "epic_store"
 version = "3.5.2"
-authors = ["Epic Foundation <epiccash@brickabode.com>"]
+authors = ["Epic Foundation <info@epiccash.com>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "epic_util"
 version = "3.5.2"
-authors = ["Epic Foundation <epiccash@brickabode.com>"]
+authors = ["Epic Foundation <info@epiccash.com>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "epic_util"
-version = "3.5.0"
+version = "3.5.2"
 authors = ["Epic Foundation <epiccash@brickabode.com>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
 repository = "https://github.com/EpicCash/epic"
 keywords = ["crypto", "epic", "mimblewimble"]
 workspace = ".."
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 backtrace = "0.3"


### PR DESCRIPTION
- Bumps version to 3.5.2 for upcoming maintenance release
- Bumps version to 3.5.2 for debian package
- Increase rust `edition` in `Cargo.toml` to 2021