### PR TITLE
Fix test compilation on rust 1.76

### DIFF
--- a/src/bin/tui/status.rs
+++ b/src/bin/tui/status.rs
@@ -329,7 +329,7 @@ fn test_status_txhashset_kernels() {
 		kernels_total: 5000,
 	};
 	let basic_status = TUIStatusView::update_sync_status(status);
-	assert!(basic_status.contains("4%"), basic_status);
+	assert!(basic_status.contains("4%"), "{}", basic_status);
 }
 
 #[test]
@@ -339,5 +339,5 @@ fn test_status_txhashset_rproofs() {
 		rproofs_total: 1000,
 	};
 	let basic_status = TUIStatusView::update_sync_status(status);
-	assert!(basic_status.contains("64%"), basic_status);
+	assert!(basic_status.contains("64%"), "{}", basic_status);
 }

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -715,7 +715,7 @@ mod mine_chain {
 					(FType::ProgPow, 0),
 				]
 				.into_iter()
-				.map(|&x| x)
+				.map(|x| x)
 				.collect();
 
 				let policies2 = [
@@ -725,7 +725,7 @@ mod mine_chain {
 					(FType::ProgPow, 0),
 				]
 				.into_iter()
-				.map(|&x| x)
+				.map(|x| x)
 				.collect();
 
 				let policies3 = [
@@ -735,7 +735,7 @@ mod mine_chain {
 					(FType::ProgPow, 100),
 				]
 				.into_iter()
-				.map(|&x| x)
+				.map(|x| x)
 				.collect();
 
 				set_policy_config(PolicyConfig {
@@ -1867,7 +1867,7 @@ fn setup() {
 		(FType::ProgPow, 0),
 	]
 	.into_iter()
-	.map(|&x| x)
+	.map(|x| x)
 	.collect();
 
 	let policies2 = [
@@ -1877,7 +1877,7 @@ fn setup() {
 		(FType::ProgPow, 0),
 	]
 	.into_iter()
-	.map(|&x| x)
+	.map(|x| x)
 	.collect();
 
 	let policies3 = [
@@ -1887,7 +1887,7 @@ fn setup() {
 		(FType::ProgPow, 100),
 	]
 	.into_iter()
-	.map(|&x| x)
+	.map(|x| x)
 	.collect();
 
 	set_policy_config(PolicyConfig {
@@ -1896,7 +1896,8 @@ fn setup() {
 	});
 	util::init_test_logger();
 }
-/// To run cucumber test: cargo test --package epic --test cucumber
+
+// To run cucumber test: cargo test --package epic --test cucumber
 cucumber! {
 	features: "./features", // Path to our feature files
 	world: crate::EdnaWorld, // The world needs to be the same for steps and the main cucumber call


### PR DESCRIPTION
Fixes compilation errors on newest stable rust toolchain. Lots of warnings to resolve, but we can handle those later.