### PR TITLE
Fix no peers by setting the correct port in the config file

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -269,7 +269,7 @@ fn comments() -> HashMap<String, String> {
 		"[server.p2p_config.capabilities]".to_string(),
 		"#If the seeding type is List, the list of peers to connect to can
 #be specified as follows:
-seeds = [\"95.217.197.180:3517\",\"5.161.127.56:3414\",\"5.75.242.4:3414\",\"5.78.71.29:3414\"]
+seeds = [\"95.217.197.180:3414\",\"5.161.127.56:3414\",\"5.75.242.4:3414\",\"5.78.71.29:3414\"]
 
 #hardcoded peer lists for allow/deny
 #will *only* connect to peers in allow list

--- a/doc/running.org
+++ b/doc/running.org
@@ -99,7 +99,7 @@ The following steps explain how to install and run the epic server:
       foundation_path = "/home/user/.epic/main/foundation.json"
     #+end_src
 
-    Also edit the same .toml file to change seeding_type to "List" and uncomment/update seeds to ["95.217.197.180:3517"]:    
+    Also edit the same .toml file to change seeding_type to "List" and uncomment/update seeds to ["95.217.197.180:3414"]:    
   
 
 #+CAPTION: Epic Server toml changes


### PR DESCRIPTION
New:
```
user@name:~$ nc -vz -w1 95.217.197.180 3414
Connection to 95.217.197.180 3414 port [tcp/*] succeeded!
```

Old:
```
user@name:~$ nc -vz -w1 95.217.197.180 3517
nc: connect to 95.217.197.180 port 3517 (tcp) timed out: Operation now in progress
```
I recommend updating the seed node list, because currently users who compile from source will not be able to sync until this is merged or the rest of the seed nodes are up:

```
user@name:~$ nc -vz -w1 5.75.242.4 3414
nc: connect to 5.75.242.4 port 3414 (tcp) failed: Connection refused
user@name:~$ nc -vz -w1 5.78.71.29 3414
nc: connect to 5.78.71.29 port 3414 (tcp) timed out: Operation now in progress
user@name:~$ nc -vz -w1 5.161.127.56 3414
nc: connect to 5.161.127.56 port 3414 (tcp) failed: Connection refused
```
